### PR TITLE
Support entitlement and evaluation editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * [Liberty on ARO](https://github.com/WASdev/azure.liberty.aro)
 * [Liberty on AKS](https://github.com/WASdev/azure.liberty.aks)
 
-# Deploy RHEL 8.4 VMs on Azure with IBM WebSphere Application Server traditional V9.0.5 single server
+# Deploy RHEL 8.4 VM on Azure with IBM WebSphere Application Server traditional V9.0.5 single server
 
 ## Prerequisites
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.singleserver</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.3</version>
     
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
@@ -39,6 +39,8 @@
         <customer.usage.attribution.id>pid-5d69db5c-7773-47d1-9455-890d05fb3c2b-partnercenter</customer.usage.attribution.id>
         <singleserver.start>0dd3f110-4c7f-5292-a624-954cc19f7c49</singleserver.start>
         <singleserver.end>b82321d6-35d9-5b24-b158-1d32a234bd71</singleserver.end>
+        <singleserver.trial.start>e2691195-adb0-5815-a9c6-5913520bb1e3</singleserver.trial.start>
+        <singleserver.trial.end>247da6d1-3922-55cb-8c0c-22387505fe54</singleserver.trial.end>
         <!-- This is the "Partner ID" in Partner Center" -->
         <image.publisher>ibm-usa-ny-armonk-hq-6275750-ibmcloud-aiops</image.publisher>
         <!-- This is the twas "Offer ID" of the "Azure Virtual Machine" offer type -->

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,6 @@
         <!-- This is the twas "Plan ID" of the plan within the "Azure Virtual Machine" offer -->
         <twas.image.sku>2022-01-06-twas-single-server-base-image</twas.image.sku>
         <!-- This is the twas "Disk version" of the VM image of the plan within the "Azure Virtual Machine" offer -->
-        <twas.image.version>9.0.20220209</twas.image.version>
+        <twas.image.version>9.0.20220303</twas.image.version>
     </properties>
 </project>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -25,12 +25,13 @@
                 }
             },
             {
-                "name": "entitlementInfo",
+                "name": "ibmIdInfo",
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "[if(bool(basics('useTrial')), 'TBD text will contain points such as: 1) BIG BOLD NO iFixes warning. 2) The trial is 60 days in duration.', 'This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href=\"https://ibm.biz/IBMidEntitlement\" target=\"_blank\">IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure.')]"
-                }
+                    "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://ibm.biz/IBMidEntitlement' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
+                },
+                "visible": "[not(bool(basics('useTrial')))]"
             },
             {
                 "name": "ibmUserId",
@@ -62,13 +63,13 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "Accept the IBM License Agreement to proceed with the deployment. <a href='https://ibm.biz/tWASBaseLicenseAzureVMs' target='_blank'>IBM WebSphere Application Server</a>."
+                    "text": "[concat(if(bool(basics('useTrial')), 'By accepting the IBM License Agreement you are accepting the Evaluation terms of the license. An evaluation deployment does not include WebSphere interim fixes (iFixes). The evaluation period runs for 60 days after which you must purchase entitlement to continue to use WebSphere.', 'Accept the IBM License Agreement to proceed with the deployment.'), ' <a href=\"https://ibm.biz/tWASBaseLicenseAzureVMs\" target=\"_blank\">IBM WebSphere Application Server</a>.')]"
                 }
             },
             {
                 "name": "acceptIBMLicenseAgreement",
                 "type": "Microsoft.Common.CheckBox",
-                "label": "I accept the IBM License Agreement.",
+                "label": "I have read and accept the IBM License Agreement.",
                 "toolTip": "Select to accept the IBM License Agreement.",
                 "constraints": {
                     "required": true,

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -7,59 +7,54 @@
             {
                 "name": "useTrial",
                 "type": "Microsoft.Common.OptionsGroup",
-                "label": "Deploy an IBM WebSphere Application Server for evaluation only?",
-                "defaultValue": "No",
-                "toolTip": "Select 'Yes' to deploy an IBM WebSphere Application Server for evaluation only. Otherwise you will be prompted to provide an entitled IBMid to deploy an IBM WebSphere Application Server with full support from IBM.",
+                "label": "Deploy with existing WebSphere entitlement or with evaluation license?",
+                "toolTip": "Select to deploy with existing WebSphere entitlement or with evaluation license.",
+                "defaultValue": "Entitled",
                 "constraints": {
                     "allowedValues": [
                         {
-                            "label": "Yes",
-                            "value": "true"
+                            "label": "Entitled",
+                            "value": "false"
                         },
                         {
-                            "label": "No",
-                            "value": "false"
+                            "label": "Evaluation",
+                            "value": "true"
                         }
                     ],
                     "required": true
                 }
             },
             {
-                "name": "ibmIdSection",
-                "type": "Microsoft.Common.Section",
-                "elements": [
-                    {
-                        "name": "ibmIdInfo",
-                        "type": "Microsoft.Common.InfoBox",
-                        "options": {
-                            "icon": "Info",
-                            "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://ibm.biz/IBMidEntitlement' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
-                        }
-                    },
-                    {
-                        "name": "ibmUserId",
-                        "type": "Microsoft.Common.TextBox",
-                        "label": "IBMid",
-                        "toolTip": "Your IBMid.",
-                        "constraints": {
-                            "required": true,
-                            "regex": "^(?!\\-)([a-z0-9A-Z@\\-]{1,128})([^\\-])",
-                            "validationMessage": "The value must be valid IBMid."
-                        }
-                    },
-                    {
-                        "name": "ibmUserPwd",
-                        "type": "Microsoft.Common.PasswordBox",
-                        "label": {
-                            "password": "Password for IBMid",
-                            "confirmPassword": "Confirm password"
-                        },
-                        "toolTip": "Password for your IBMid.",
-                        "constraints": {
-                            "required": true
-                        }
-                    }
-                ],
+                "name": "entitlementInfo",
+                "type": "Microsoft.Common.InfoBox",
+                "options": {
+                    "icon": "Info",
+                    "text": "[if(bool(basics('useTrial')), 'TBD text will contain points such as: 1) BIG BOLD NO iFixes warning. 2) The trial is 60 days in duration.', 'This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href=\"https://ibm.biz/IBMidEntitlement\" target=\"_blank\">IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure.')]"
+                }
+            },
+            {
+                "name": "ibmUserId",
+                "type": "Microsoft.Common.TextBox",
+                "label": "IBMid",
+                "toolTip": "Your IBMid.",
+                "constraints": {
+                    "required": true,
+                    "regex": "^(?!\\-)([a-z0-9A-Z@\\-]{1,128})([^\\-])",
+                    "validationMessage": "The value must be valid IBMid."
+                },
+                "visible": "[not(bool(basics('useTrial')))]"
+            },
+            {
+                "name": "ibmUserPwd",
+                "type": "Microsoft.Common.PasswordBox",
+                "label": {
+                    "password": "Password for IBMid",
+                    "confirmPassword": "Confirm password"
+                },
+                "toolTip": "Password for your IBMid.",
+                "constraints": {
+                    "required": true
+                },
                 "visible": "[not(bool(basics('useTrial')))]"
             },
             {
@@ -237,8 +232,8 @@
         "outputs": {
             "location": "[location()]",
             "useTrial": "[bool(basics('useTrial'))]",
-            "ibmUserId": "[basics('ibmIdSection').ibmUserId]",
-            "ibmUserPwd": "[basics('ibmIdSection').ibmUserPwd]",
+            "ibmUserId": "[basics('ibmUserId')]",
+            "ibmUserPwd": "[basics('ibmUserPwd')]",
             "vmSize": "[steps('SingleServerConfig').vmSizeSelect]",
             "dnsLabelPrefix": "[steps('SingleServerConfig').dnsLabelPrefix]",
             "adminUsername": "[steps('SingleServerConfig').adminUsername]",

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -5,35 +5,62 @@
     "parameters": {
         "basics": [
             {
-                "name": "ibmIdInfo",
-                "type": "Microsoft.Common.InfoBox",
-                "options": {
-                    "icon": "Info",
-                    "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://ibm.biz/IBMidEntitlement' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
-                }
-            },
-            {
-                "name": "ibmUserId",
-                "type": "Microsoft.Common.TextBox",
-                "label": "IBMid",
-                "toolTip": "Your IBMid.",
+                "name": "useTrial",
+                "type": "Microsoft.Common.OptionsGroup",
+                "label": "Deploy an IBM WebSphere Application Server for evaluation only?",
+                "defaultValue": "No",
+                "toolTip": "Select 'Yes' to deploy an IBM WebSphere Application Server for evaluation only. Otherwise you will be prompted to provide an entitled IBMid to deploy an IBM WebSphere Application Server with full support from IBM.",
                 "constraints": {
-                    "required": true,
-                    "regex": "^(?!\\-)([a-z0-9A-Z@\\-]{1,128})([^\\-])",
-                    "validationMessage": "The value must be valid IBMid."
-                }
-            },
-            {
-                "name": "ibmUserPwd",
-                "type": "Microsoft.Common.PasswordBox",
-                "label": {
-                    "password": "Password for IBMid",
-                    "confirmPassword": "Confirm password"
-                },
-                "toolTip": "Password for your IBMid.",
-                "constraints": {
+                    "allowedValues": [
+                        {
+                            "label": "Yes",
+                            "value": "true"
+                        },
+                        {
+                            "label": "No",
+                            "value": "false"
+                        }
+                    ],
                     "required": true
                 }
+            },
+            {
+                "name": "ibmIdSection",
+                "type": "Microsoft.Common.Section",
+                "elements": [
+                    {
+                        "name": "ibmIdInfo",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href='https://ibm.biz/IBMidEntitlement' target='_blank'>IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure."
+                        }
+                    },
+                    {
+                        "name": "ibmUserId",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "IBMid",
+                        "toolTip": "Your IBMid.",
+                        "constraints": {
+                            "required": true,
+                            "regex": "^(?!\\-)([a-z0-9A-Z@\\-]{1,128})([^\\-])",
+                            "validationMessage": "The value must be valid IBMid."
+                        }
+                    },
+                    {
+                        "name": "ibmUserPwd",
+                        "type": "Microsoft.Common.PasswordBox",
+                        "label": {
+                            "password": "Password for IBMid",
+                            "confirmPassword": "Confirm password"
+                        },
+                        "toolTip": "Password for your IBMid.",
+                        "constraints": {
+                            "required": true
+                        }
+                    }
+                ],
+                "visible": "[not(bool(basics('useTrial')))]"
             },
             {
                 "name": "licenseInfo",
@@ -209,8 +236,9 @@
         ],
         "outputs": {
             "location": "[location()]",
-            "ibmUserId": "[basics('ibmUserId')]",
-            "ibmUserPwd": "[basics('ibmUserPwd')]",
+            "useTrial": "[bool(basics('useTrial'))]",
+            "ibmUserId": "[basics('ibmIdSection').ibmUserId]",
+            "ibmUserPwd": "[basics('ibmIdSection').ibmUserPwd]",
             "vmSize": "[steps('SingleServerConfig').vmSizeSelect]",
             "dnsLabelPrefix": "[steps('SingleServerConfig').dnsLabelPrefix]",
             "adminUsername": "[steps('SingleServerConfig').adminUsername]",

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -25,12 +25,14 @@
         },
         "ibmUserId": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Username of your IBMid account."
             }
         },
         "ibmUserPwd": {
             "type": "securestring",
+            "defaultValue": "",
             "metadata": {
                 "description": "Password of your IBMid account."
             }

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -26,7 +26,7 @@
         "useTrial": {
             "type": "bool",
             "metadata": {
-                "description": "Boolean value indicating, if use wants to deploy a tWAS single server for evaluation only."
+                "description": "Boolean value indicating, if user wants to deploy a tWAS single server for evaluation only."
             }
         },
         "ibmUserId": {

--- a/src/main/arm/mainTemplate.json
+++ b/src/main/arm/mainTemplate.json
@@ -23,6 +23,12 @@
                 "description": "Location for all resources."
             }
         },
+        "useTrial": {
+            "type": "bool",
+            "metadata": {
+                "description": "Boolean value indicating, if use wants to deploy a tWAS single server for evaluation only."
+            }
+        },
         "ibmUserId": {
             "type": "string",
             "defaultValue": "",
@@ -136,7 +142,7 @@
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
-            "name": "${singleserver.start}",
+            "name": "[if(parameters('useTrial'), '${singleserver.trial.start}', '${singleserver.start}')]",
             "properties": {
                 "mode": "Incremental",
                 "template": {
@@ -281,7 +287,7 @@
                     "adminUsername": "[parameters('adminUsername')]",
                     "adminPassword": "[parameters('adminPasswordOrKey')]",
                     "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('const_linuxConfiguration'))]",
-                    "customData": "[base64(concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd')))]"
+                    "customData": "[base64(if(parameters('useTrial'), ' ', concat(parameters('ibmUserId'), ' ', parameters('ibmUserPwd'))))]"
                 },
                 "networkProfile": {
                     "networkInterfaces": [
@@ -340,7 +346,7 @@
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "${azure.apiVersion}",
-            "name": "${singleserver.end}",
+            "name": "[if(parameters('useTrial'), '${singleserver.trial.end}', '${singleserver.end}')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Compute/virtualMachines/extensions', variables('name_virtualMachine'), 'install')]"
             ],

--- a/src/main/arm/parameters.json
+++ b/src/main/arm/parameters.json
@@ -5,6 +5,9 @@
         "_artifactsLocation": {
             "value": "${artifactsLocationBase}/src/main/"
         },
+        "useTrial": {
+            "value": "${useTrial}"
+        },
         "ibmUserId": {
             "value": "${ibmUserId}"
         },

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -126,6 +126,8 @@ resourceGroupLocation=$( az group show --name $resourceGroupName | jq -r '.locat
 
 #parameters JSON
 parametersJson=$( cat $parametersFilePath | jq '.parameters' )
+useTrial=$( echo $parametersJson | jq '.useTrial.value' | sed 's/"//g' )
+parametersJson=$( echo $parametersJson | jq --argjson useTrial "$useTrial" '.useTrial.value = $useTrial' )
 parametersJson=$( echo "$parametersJson" | jq -c '.' )
 
 #Start deployment

--- a/src/main/scripts/install.sh
+++ b/src/main/scripts/install.sh
@@ -77,7 +77,7 @@ isDone=false
 while [ $isDone = false ]
 do
     result=`(tail -n1) <$WAS_LOG_PATH`
-    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]]; then
+    if [[ $result = $ENTITLED ]] || [[ $result = $UNENTITLED ]] || [[ $result = $UNDEFINED ]] || [[ $result = $EVALUATION ]]; then
         isDone=true
     else
         sleep 5
@@ -88,7 +88,7 @@ done
 cloud-init clean --logs
 
 # Terminate the process for the un-entitled or undefined user
-if [ ${result} != $ENTITLED ]; then
+if [ ${result} != $ENTITLED ] && [ ${result} != $EVALUATION ]; then
     if [ ${result} = $UNENTITLED ]; then
         echo "The provided IBMid does not have entitlement to install WebSphere Application Server. Please contact the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at IBM eCustomer Care (https://ibm.biz/IBMidEntitlement) for further assistance."
     else


### PR DESCRIPTION
## Description

The PR is to resolve #23 and resolve #24 so that the twas-single-server offer can support both entitlement and evaluation usages.

## Testing

The following test cases are passed before sending out the PR:
* Deployment in **Entitled** mode:
   * Successfully deployed a tWAS base single server on Azure VM using an entitled IBMid
   * Failed to deploy a tWAS base single server on Azure VM using an invalid IBMid
* Deployment in **Evaluation license** mode:
   * Successfully deployed a tWAS base single server on Azure VM without IBMid

Here is the [preview link](https://portal.azure.com/#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwas-single-server) for live testing.

Signed-off-by: Jianguo Ma [jiangma@microsoft.com](mailto:jiangma@microsoft.com)