### PR TITLE
access the image source vm if cicd failed

### DIFF
--- a/docs/howto-update-for-was-fixpack.md
+++ b/docs/howto-update-for-was-fixpack.md
@@ -23,6 +23,7 @@ Please follow sections below in order to update the solution for next tWAS base 
 
 1. How to test the image, what testcases to run?
    * The CI/CD contains tests to verify the entitlement check and tWAS installation, so basically it's good to go without manual tests.
+   * However, if CI/CD failed, please look at error messages from the CI/CD logs, and [access the source VM](https://github.com/WASdev/azure.websphere-traditional.image/blob/main/docs/howto-access-source-vm.md) for troubleshooting if necessary.
 
 1. How to publish the image **as a hidden image** in marketplace and who can do it?
    1. Wait until the CI/CD workflow for `twas-base CICD` successfully completes > Click to open details of the workflow run > Scroll to the bottom of the page > Click `sasurl` to download the zip file `sasurl.zip` > Unzip and open file `sas-url.txt` > Find values for `osDiskSasUrl` and `dataDiskSasUrl`;


### PR DESCRIPTION
The PR is related to the primary PR WASdev/azure.websphere-traditional.image/pull/59, which adds a link to how-to guide about access the source vm when cicd failed.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>