### PR TITLE
Reference guide about how to cleanup after image is published

### DIFF
--- a/docs/howto-update-for-was-fixpack.md
+++ b/docs/howto-update-for-was-fixpack.md
@@ -44,6 +44,7 @@ Please follow sections below in order to update the solution for next tWAS base 
       * Click `Publish`;
       * Wait for few hours to a day, keep refreshing the page until "Go Live" button appears
       * Click on "Go Live" and wait again (for few hours) for the image to be published.
+      * **Note:** After the image is successfully published and available, please [clean up the storage account with VHD files](https://github.com/WASdev/azure.websphere-traditional.image/blob/main/docs/howto-cleanup-after-image-published.md) for reducing Azure cost.
       * Now proceed to [Updating and publishing the solution code](#updating-and-publishing-the-solution-code) steps
 
    Note: Currently Graham Charters has privilege to update the image in marketplace, contact him for more information.


### PR DESCRIPTION
This PR is to reference the guide created by WASdev/azure.websphere-traditional.image/pull/60 to instruct user to clean up the storage account for reducing Azure cost.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>