### PR TITLE
Bring your own VNet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.singleserver</artifactId>
-    <version>1.1.0</version>
+    <version>1.0.7</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -227,6 +227,53 @@
                         }
                     }
                 ]
+            },
+            {
+                "name": "NetworkingConfig",
+                "label": "Networking",
+                "subLabel": {
+                    "preValidation": "Provide required information for networking",
+                    "postValidation": "Done"
+                },
+                "bladeTitle": "Networking",
+                "elements": [
+                    {
+                        "name": "vnetForSingleServer",
+                        "type": "Microsoft.Network.VirtualNetworkCombo",
+                        "label": {
+                            "virtualNetwork": "Virtual network",
+                            "subnets": "Subnets"
+                        },
+                        "toolTip": {
+                            "virtualNetwork": "Name of the virtual network",
+                            "subnets": "Subnets for the virtual network"
+                        },
+                        "defaultValue": {
+                            "name": "[concat('twassingle-vnet',take(guid(), 8))]",
+                            "addressPrefixSize": "/24"
+                        },
+                        "constraints": {
+                            "minAddressPrefixSize": "/24"
+                        },
+                        "options": {
+                            "hideExisting": false
+                        },
+                        "subnets": {
+                            "subnet1": {
+                                "label": "Subnet",
+                                "defaultValue": {
+                                    "name": "twas-single-subnet",
+                                    "addressPrefixSize": "/24"
+                                },
+                                "constraints": {
+                                    "minAddressPrefixSize": "/24",
+                                    "minAddressCount": 38,
+                                    "requireContiguousAddresses": false
+                                }
+                            }
+                        }
+                    }
+                ]
             }
         ],
         "outputs": {
@@ -240,7 +287,10 @@
             "adminPasswordOrKey": "[if(equals(steps('SingleServerConfig').adminPasswordOrKey.authenticationType, 'password'), steps('SingleServerConfig').adminPasswordOrKey.password, steps('SingleServerConfig').adminPasswordOrKey.sshPublicKey)]",
             "authenticationType": "[steps('SingleServerConfig').adminPasswordOrKey.authenticationType]",
             "wasUsername": "[steps('SingleServerConfig').wasUsername]",
-            "wasPassword": "[steps('SingleServerConfig').wasPassword]"
+            "wasPassword": "[steps('SingleServerConfig').wasPassword]",
+            "vnetForSingleServer": "[steps('NetworkingConfig').vnetForSingleServer]",
+            "newOrExistingVnetForSingleServer": "[steps('NetworkingConfig').vnetForSingleServer.newOrExisting]",
+            "vnetRGNameForSingleServer": "[steps('NetworkingConfig').vnetForSingleServer.resourceGroup]"
         }
     }
 }

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -211,6 +211,9 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2021-08-01' = if 
       internalDnsNameLabel: name_virtualMachine
     }
   }
+  dependsOn: [
+    virtualNetwork
+  ]
 }
 
 resource networkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2021-08-01' = if (!const_newVNet) {


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #35

## Change summary

* Add `Microsoft.Network.VirtualNetworkCombo` to `createUiDefinition.json` so user can create a new VNet or select an existing VNet;
* Update `mainTemplate.bicep` to support creating a new VNet or use the existing VNet per user input
   * For the case of using the existing VNet, no public IP address created and assigned to network interface

## Testing

The following test cases have already been passed before opening the PR:

* Successfully deployed a twas-base single server with a new VNet on an Azure VM with evaluation license using the preview link below.
* Successfully deployed a twas-base single server with an existing VNet on an Azure VM with evaluation license using the preview link below.

Here is the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwas-single-server) for live testing.

## UI changes review

Besides visiting [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwas-single-server) for reviewing new blade `Networking`, reviewer can preview the UI changes using the **Create UI Definition Sandbox**:

- Open [Create UI Definition Sandbox](https://portal.azure.com/?feature.customPortal=false#blade/Microsoft_Azure_CreateUIDef/SandboxBlade) in a new tab of browser.
- Open UI source code [createUiDefinition.txt](https://raw.githubusercontent.com/majguo/azure.websphere-traditional.singleserver/bring-your-own-vnet/src/main/arm/createUiDefinition.json) in a new tab of the browser.
- Replace the content of work area in **Create UI Definition Sandbox** with the content of **UI source code `createUiDefinition.json`**.
- Click **Preview** at the left-bottom of **Create UI Definition Sandbox**.
- Switch to `Networking` tab > Start UI content review. **Note**: **Configure virtual networks** is a standard component from Azure Portal, only the following text can be customized:
   - Label of new blade `Networking`
   - Label `Virtual network` and its tooltip `Name of the virtual network`
   - Label `Subnet` and its tooltip `Subnets for the virtual network`

Here is the screenshot of user experience design, see new blade **Networking** within the red-line box:
![image](https://user-images.githubusercontent.com/10357495/178196937-86186cba-17ec-4514-a153-4eb2891c4c29.png)
Signed-off-by: Jianguo Ma <jiangma@microsoft.com>