### PR TITLE
Add an info box to help user provide a workable vNet and subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@
 1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)
    1. Change to directory hosting the repo project & run `mvn clean install`
 1. Checkout [arm-ttk](https://github.com/Azure/arm-ttk) under the specified parent directory
+   1. Run `git checkout cf5c927eaf1f5652556e86a6b67816fc910d1b74` to checkout the verified version of `arm-ttk`
 1. Checkout this repo under the same parent directory and change to directory hosting the repo project
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
 
    ```bash
-   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DibmUserId=<ibmUserId> -DibmUserPwd=<ibmUserPwd> -DvmSize=<vmSize> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DuseTrial=true -DvmSize=<vmSize> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
    ```
 
 1. Change to `./target/cli` directory

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.singleserver</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -238,6 +238,14 @@
                 "bladeTitle": "Networking",
                 "elements": [
                     {
+                        "name": "vnetInfo",
+                        "type": "Microsoft.Common.InfoBox",
+                        "options": {
+                            "icon": "Info",
+                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /28 and a minimum subnet size of /29 are required. Additionally, the subnet must have adequate available addresses for the server setup."
+                        }
+                    },
+                    {
                         "name": "vnetForSingleServer",
                         "type": "Microsoft.Network.VirtualNetworkCombo",
                         "label": {
@@ -250,10 +258,10 @@
                         },
                         "defaultValue": {
                             "name": "[concat('twassingle-vnet',take(guid(), 8))]",
-                            "addressPrefixSize": "/24"
+                            "addressPrefixSize": "/28"
                         },
                         "constraints": {
-                            "minAddressPrefixSize": "/24"
+                            "minAddressPrefixSize": "/28"
                         },
                         "options": {
                             "hideExisting": false
@@ -263,11 +271,11 @@
                                 "label": "Subnet",
                                 "defaultValue": {
                                     "name": "twas-single-subnet",
-                                    "addressPrefixSize": "/24"
+                                    "addressPrefixSize": "/29"
                                 },
                                 "constraints": {
-                                    "minAddressPrefixSize": "/24",
-                                    "minAddressCount": 38,
+                                    "minAddressPrefixSize": "/29",
+                                    "minAddressCount": 1,
                                     "requireContiguousAddresses": false
                                 }
                             }


### PR DESCRIPTION
As the minimum vnet and subnet size are specified, and the subnet needs to have adequate available addresses for the server setup, an info box is added to help user provide a workable vNet and subnet.

Here is the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwas-single-server) for testing.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>