### PR TITLE
Inline partner center tracking id in template

### DIFF
--- a/docs/howto-update-for-was-fixpack.md
+++ b/docs/howto-update-for-was-fixpack.md
@@ -51,7 +51,7 @@ Please follow sections below in order to update the solution for next tWAS base 
    Note: Currently Graham Charters has privilege to update the image in marketplace, contact him for more information.
 
 1. Do we need to update the solution every time we do the image update?
-   * Yes. That's because image version of [`twas-base`](https://github.com/WASdev/azure.websphere-traditional.singleserver/blob/main/src/main/bicep/config.json#L14) is explicitely referenced in the tWAS base single server solution. Make sure correct image version is specified in the `config.json` of the solution code.
+   * Yes. That's because image version of [`twas-base`](https://github.com/WASdev/azure.websphere-traditional.singleserver/blob/main/src/main/bicep/config.json#L13) is explicitely referenced in the tWAS base single server solution. Make sure correct image version is specified in the `config.json` of the solution code.
 
 ## Updating and publishing the solution code
 
@@ -59,7 +59,7 @@ Note: **Wait for images to be published before proceeding with this step.** The 
 
 1. How to update the version of the solution?
    * Increase the [version number](https://github.com/WASdev/azure.websphere-traditional.singleserver/blob/main/pom.xml#L22) which is specified in the `pom.xml`
-   * Also update the [`twasImageVersion`](https://github.com/WASdev/azure.websphere-traditional.singleserver/blob/main/src/main/bicep/config.json#L14) in the `config.json` (obtained from publish step)
+   * Also update the [`twasImageVersion`](https://github.com/WASdev/azure.websphere-traditional.singleserver/blob/main/src/main/bicep/config.json#L13) in the `config.json` (obtained from publish step)
    * Get the PR merged
 
 1. How to run CI/CD?

--- a/src/main/bicep/config.json
+++ b/src/main/bicep/config.json
@@ -1,5 +1,4 @@
 {
-    "customerUsageAttributionId": "pid-5d69db5c-7773-47d1-9455-890d05fb3c2b-partnercenter",
     "singleserverStart": "0dd3f110-4c7f-5292-a624-954cc19f7c49",
     "singleserverEnd": "b82321d6-35d9-5b24-b158-1d32a234bd71",
     "singleserverTrialStart": "e2691195-adb0-5815-a9c6-5913520bb1e3",

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -111,7 +111,7 @@ var configBase64 = loadFileAsBase64('config.json')
 var config = base64ToJson(configBase64)
 
 module partnerCenterPid './modules/_pids/_empty.bicep' = {
-  name: config.customerUsageAttributionId
+  name: 'pid-5d69db5c-7773-47d1-9455-890d05fb3c2b-partnercenter'
   params: {}
 }
 


### PR DESCRIPTION
Partner center requires the tracking pid is inlined in the main template, the PR is to move the pid from `config.json` to `mainTemplate.bicep` to satisfy the requirement. The expected result is verified with this [workflow run](https://github.com/majguo/azure.websphere-traditional.singleserver/actions/runs/2674690348).

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>