### PR TITLE
Fix arm-ttk test failure: Parameters property must exist in the template

### DIFF
--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -66,15 +66,15 @@ param vnetForSingleServer object = {
   name: 'twassingle-vnet'
   resourceGroup: resourceGroup().name
   addressPrefixes: [
-    '10.0.0.0/24'
+    '10.0.0.32/28'
   ]
-  addressPrefix: '10.0.0.0/24'
+  addressPrefix: '10.0.0.32/28'
   newOrExisting: 'new'
   subnets: {
     subnet1: {
       name: 'twassingle-subnet'
-      addressPrefix: '10.0.0.0/24'
-      startAddress: '10.0.0.4'
+      addressPrefix: '10.0.0.32/29'
+      startAddress: '10.0.0.36'
     }
   }
 }

--- a/src/main/bicep/modules/_pids/_empty.bicep
+++ b/src/main/bicep/modules/_pids/_empty.bicep
@@ -13,3 +13,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+
+// Workaround to arm-ttk complain: Parameters property must exist in the template
+param name string = 'This is an empty deployment'
+
+output name string = name


### PR DESCRIPTION
Refer to oracle/weblogic-azure/issues/171, I downloaded the arm-ttk version that partner center is using (https://aka.ms/arm-ttk-azureapps) and ran tests in my local, found the following failure:

```
NestedTemplate pid-5d69db5c-7773-47d1-9455-890d05fb3c2b-partnercenter [
 Lines 365 - 788 ]
    [-] Parameters Property Must Exist (129 ms)
        Parameters property must exist in the template

   NestedTemplate [if(parameters('useTrial'), variables('config').singlese
rverTrialStart, variables('config').singleserverStart)] [ Lines 389 - 812 ]
    [-] Parameters Property Must Exist (129 ms)
        Parameters property must exist in the template

   NestedTemplate singleServerVMCreated [ Lines 413 - 836 ]
    [-] Parameters Property Must Exist (129 ms)
        Parameters property must exist in the template
```

After applying the changes of the PR (leveraged from [here ](https://github.com/oracle/weblogic-azure/blob/main/weblogic-azure-aks/src/main/bicep/modules/_pids/_empty.bicep#L12-L15)), the failures are fixed.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>