### PR TITLE
Integration test pipeline

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -4,7 +4,7 @@ on:
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.singleserver
-  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/package.yaml/dispatches --data '{"ref": "main"}'
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
     types: [integration-test]
   # sample request

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -127,3 +127,27 @@ jobs:
         with:
           name: ${{steps.artifact_file.outputs.artifactName}}
           path: ${{steps.artifact_file.outputs.artifactPath}}
+  notification:
+    needs: integration-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification
+        if: always()
+        run: |
+            workflowJobs=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${{ env.userName }}/${{ env.repoName }}/actions/runs/${{ github.run_id }}/jobs)
+            successIntegrationTestJob=$(echo $workflowJobs | jq '.jobs | map(select(.name=="integration-test" and .conclusion=="success")) | length')
+            if (($successIntegrationTestJob == 0));then
+                echo "Job integration-test failed, send notification to Teams"
+                curl ${{ env.msTeamsWebhook }} \
+                -H 'Content-Type: application/json' \
+                --data-binary @- << EOF
+                {
+                "@context":"http://schema.org/extensions",
+                "@type":"MessageCard",
+                "text":"Workflow integration-test of repo ${{ env.repoName }} failed, please take a look at: https://github.com/${{ env.userName }}/${{ env.repoName }}/actions/runs/${{ github.run_id }}"
+                }
+            EOF
+            else
+                echo "Job integration-test succeeded."
+            fi

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -6,12 +6,11 @@ on:
   # REPO_NAME=WASdev/azure.websphere-traditional.singleserver
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/package.yaml/dispatches --data '{"ref": "main"}'
   repository_dispatch:
-    types: [integration-test, package]
+    types: [integration-test]
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.singleserver
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
-  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
 env:
   # Latest version is at https://github.com/Azure/azure-cli/releases
   azCliVersion: 2.31.0
@@ -106,6 +105,14 @@ jobs:
             echo "Failed to access ${snoopServletUrl}."
             exit 1
           fi
+      - name: Delete all Azure resources
+        id: delete-resources-in-group
+        if: always()
+        uses: azure/CLI@v1
+        with:
+          azcliversion: ${{ env.azCliVersion }}
+          inlineScript: |
+            az group delete -n ${{ env.testResourceGroup }} --yes
       - name: Generate artifact file name and path
         id: artifact_file
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -30,7 +30,7 @@ env:
   testDeploymentName: twasSingleTestDeployment${{ github.run_id }}${{ github.run_number }}
   location: eastus
 jobs:
-  package:
+  integration-test:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 1.8
@@ -77,9 +77,10 @@ jobs:
       - name: Deploy a twas-single server on Azure VM
         run: |
           cd ${{ env.repoName }}/target/cli
+          chmod a+x deploy.azcli
           echo "Starting deployment..."
           (
-            ./deploy.azcli -n ${{ env.testDeploymentName }} -i $(echo ${{ env.azureCredentials }} | jq '.subscriptionId') -g ${{ env.testResourceGroup }} -l ${{ env.location }}
+            ./deploy.azcli -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} -l ${{ env.location }}
           )
           if [[ $? -eq 0 ]]; then
             echo "Template has been successfully deployed"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -79,7 +79,7 @@ jobs:
           cd ${{ env.repoName }}/target/cli
           echo "Starting deployment..."
           (
-            ./deploy.azcli -n ${{ env.testDeploymentName }} -i $(echo ${{ env.azureCredentials. }} | jq '.subscriptionId') -g ${{ env.testResourceGroup }} -l ${{ env.location }}
+            ./deploy.azcli -n ${{ env.testDeploymentName }} -i $(echo ${{ env.azureCredentials }} | jq '.subscriptionId') -g ${{ env.testResourceGroup }} -l ${{ env.location }}
           )
           if [[ $? -eq 0 ]]; then
             echo "Template has been successfully deployed"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -85,6 +85,27 @@ jobs:
           if [[ $? -eq 0 ]]; then
             echo "Template has been successfully deployed"
           fi
+      - name: Verify the deployment
+        run: |
+          outputs=$(az deployment group show -n ${{ env.testDeploymentName }} -g ${{ env.testResourceGroup }} --query 'properties.outputs')
+          adminSecuredConsole=$(echo $outputs | jq -r '.adminSecuredConsole.value')
+          curl $adminSecuredConsole -k
+          if [[ $? -ne 0 ]]; then
+            echo "Failed to access ${adminSecuredConsole}."
+            exit 1
+          fi
+          hitCountServletUrl=$(echo $outputs | jq -r '.hitCountServletUrl.value')
+          curl $hitCountServletUrl -k
+          if [[ $? -ne 0 ]]; then
+            echo "Failed to access ${hitCountServletUrl}."
+            exit 1
+          fi
+          snoopServletUrl=$(echo $outputs | jq -r '.snoopServletUrl.value')
+          curl $snoopServletUrl -k
+          if [[ $? -ne 0 ]]; then
+            echo "Failed to access ${snoopServletUrl}."
+            exit 1
+          fi
       - name: Generate artifact file name and path
         id: artifact_file
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,4 +1,4 @@
-name: Package ARM
+name: integration-test
 on:
   workflow_dispatch:
   # Allows you to run this workflow using GitHub APIs

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,100 @@
+name: Package ARM
+on:
+  workflow_dispatch:
+  # Allows you to run this workflow using GitHub APIs
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.websphere-traditional.singleserver
+  # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/package.yaml/dispatches --data '{"ref": "main"}'
+  repository_dispatch:
+    types: [integration-test, package]
+  # sample request
+  # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
+  # REPO_NAME=WASdev/azure.websphere-traditional.singleserver
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test"}'
+  # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "package"}'
+env:
+  # Latest version is at https://github.com/Azure/azure-cli/releases
+  azCliVersion: 2.31.0
+  # Commit hash from https://github.com/Azure/arm-ttk/commits/master
+  refArmttk: cf5c927eaf1f5652556e86a6b67816fc910d1b74
+  # Commit hash from https://github.com/Azure/azure-javaee-iaas/commits/main
+  refJavaee: f25ab89a2a8848da39b84e5d6c927f4c4cb47200
+  bicepVersion: v0.7.4
+  repoName: "azure.websphere-traditional.singleserver"
+  azureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+  userName: ${{ secrets.USER_NAME }}
+  msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
+  vmAdminId: ${{ secrets.VM_ADMIN_ID }}
+  vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
+  testResourceGroup: twasSingleTestRG${{ github.run_id }}${{ github.run_number }}
+  testDeploymentName: twasSingleTestDeployment${{ github.run_id }}${{ github.run_number }}
+  location: eastus
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Set up bicep
+        run: |
+          curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
+          chmod +x ./bicep
+          sudo mv ./bicep /usr/local/bin/bicep
+          bicep --version
+      - name: Checkout azure-javaee-iaas
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/azure-javaee-iaas
+          path: azure-javaee-iaas
+          ref: ${{ env.refJavaee }}
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v2
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
+          ref: ${{ env.refArmttk }}
+      - name: Checkout ${{ env.repoName }}
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.repoName }}
+          ref: ${{ github.event.inputs.ref }}
+      - name: Build azure-javaee-iaas
+        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+      - name: Build ${{ env.repoName }}
+        run: |
+          cd ${{ env.repoName }}
+          mvn -Dgit.repo=${{ env.userName }} -Dgit.tag=$GITHUB_REF_NAME -DuseTrial=true \
+            -DvmSize=Standard_D2_v3 -DdnsLabelPrefix=was \
+            -DadminUsername=${{ env.vmAdminId }} -DadminPasswordOrKey=${{ env.vmAdminPassword }} \
+            -DauthenticationType=password -DwasUsername=${{ env.vmAdminId }} -DwasPassword=${{ env.vmAdminPassword }} \
+            -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+      - uses: azure/login@v1
+        id: azure-login
+        with:
+          creds: ${{ env.azureCredentials }}
+      - name: Deploy a twas-single server on Azure VM
+        run: |
+          cd ${{ env.repoName }}/target/cli
+          echo "Starting deployment..."
+          (
+            ./deploy.azcli -n ${{ env.testDeploymentName }} -i $(echo ${{ env.azureCredentials. }} | jq '.subscriptionId') -g ${{ env.testResourceGroup }} -l ${{ env.location }}
+          )
+          if [[ $? -eq 0 ]]; then
+            echo "Template has been successfully deployed"
+          fi
+      - name: Generate artifact file name and path
+        id: artifact_file
+        run: |
+          version=$(awk '/<version>[^<]+<\/version>/{gsub(/<version>|<\/version>/,"",$1);print $1;exit;}' ${{ env.repoName }}/pom.xml)
+          artifactName=${{ env.repoName }}-$version-arm-assembly
+          unzip ${{ env.repoName }}/target/$artifactName.zip -d ${{ env.repoName }}/target/$artifactName
+          echo "##[set-output name=artifactName;]${artifactName}"
+          echo "##[set-output name=artifactPath;]${{ env.repoName }}/target/$artifactName"
+      - name: Archive ${{ env.repoName }} template
+        uses: actions/upload-artifact@v1
+        if: success()
+        with:
+          name: ${{steps.artifact_file.outputs.artifactName}}
+          path: ${{steps.artifact_file.outputs.artifactPath}}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 1. Using `deploy.azcli` to deploy
 
    ```bash
-   ./deploy.azcli -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>
+   ./deploy.azcli -n <deploymentName> -g <resourceGroupName> -l <resourceGroupLocation>
    ```
 
 ## After deployment

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -322,6 +322,6 @@ module singleServerEndPid './modules/_pids/_empty.bicep' = {
   ]
 }
 
-output adminSecuredConsole string = uri(format('https://{0}:9043/', const_newVNet ? publicIPAddress.properties.dnsSettings.fqdn : reference(name_networkInterfaceNoPubIp).ipConfigurations[0].properties.privateIPAddress), 'ibm/console')
+output adminSecuredConsole string = uri(format('https://{0}:9043/', const_newVNet ? publicIPAddress.properties.dnsSettings.fqdn : reference(name_networkInterfaceNoPubIp).ipConfigurations[0].properties.privateIPAddress), 'ibm/console/logon.jsp')
 output snoopServletUrl string = uri(format('https://{0}:9443/', const_newVNet ? publicIPAddress.properties.dnsSettings.fqdn : reference(name_networkInterfaceNoPubIp).ipConfigurations[0].properties.privateIPAddress), 'snoop')
 output hitCountServletUrl string = uri(format('https://{0}:9443/', const_newVNet ? publicIPAddress.properties.dnsSettings.fqdn : reference(name_networkInterfaceNoPubIp).ipConfigurations[0].properties.privateIPAddress), 'hitcount')

--- a/src/main/cli/deploy.azcli
+++ b/src/main/cli/deploy.azcli
@@ -21,10 +21,9 @@ IFS=$'\n\t'
 # -o: prevents errors in a pipeline from being masked
 # IFS new value is less likely to cause confusing bugs when looping arrays or arguments (e.g. $@)
 
-usage() { echo "Usage: $0 -n <deploymentName> -i <subscriptionId> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
+usage() { echo "Usage: $0 -n <deploymentName> -g <resourceGroupName> -l <resourceGroupLocation>" 1>&2; exit 1; }
 
 declare deploymentName=""
-declare subscriptionId=""
 declare resourceGroupName=""
 declare resourceGroupLocation=""
 
@@ -33,9 +32,6 @@ while getopts ":n:i:g:l:" arg; do
 	case "${arg}" in
 		n)
 			deploymentName=${OPTARG}
-			;;
-		i)
-			subscriptionId=${OPTARG}
 			;;
 		g)
 			resourceGroupName=${OPTARG}
@@ -51,13 +47,6 @@ shift $((OPTIND-1))
 if [[ -z "$deploymentName" ]]; then
 	echo "Enter a name for this deployment:"
 	read deploymentName
-fi
-
-if [[ -z "$subscriptionId" ]]; then
-	echo "Your subscription ID can be looked up with the CLI using: az account show --out json "
-	echo "Enter your subscription ID:"
-	read subscriptionId
-	[[ "${subscriptionId:?}" ]]
 fi
 
 if [[ -z "$resourceGroupName" ]]; then
@@ -76,8 +65,8 @@ if [[ -z "$resourceGroupLocation" ]]; then
 	read resourceGroupLocation
 fi
 
-if [ -z "$deploymentName" ] || [ -z "$subscriptionId" ] || [ -z "$resourceGroupName" ]; then
-	echo "Either one of deploymentName, subscriptionId and resourceGroupName is empty"
+if [ -z "$deploymentName" ] || [ -z "$resourceGroupName" ]; then
+	echo "Either one of deploymentName and resourceGroupName is empty"
 	usage
 fi
 
@@ -103,9 +92,6 @@ az account show 1> /dev/null
 if [ $? != 0 ]; then
 	az login
 fi
-
-#set the default subscription id
-az account set --subscription $subscriptionId
 
 set +e
 


### PR DESCRIPTION
The PR is to resolve #42 by adding a new pipeline which supports for integration testing, typically:
* Deploy a twas-single on an Azure VM
* Verify the deployment by accessing the WebSphere admin console and the application deployed by default
* Clean up Azure resources at the end of workflow

See the successful rans of pipeline:
* [integration-test · majguo/azure.websphere-traditional.singleserver@0ef7084 (github.com)](https://github.com/majguo/azure.websphere-traditional.singleserver/actions/runs/2967882466)
* [integration-test · majguo/azure.websphere-traditional.singleserver@1b1f956 (github.com)](https://github.com/majguo/azure.websphere-traditional.singleserver/actions/runs/2968032636)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>