### PR TITLE
Support Microsoft SQL Server database connection

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,6 +10,8 @@ on:
         options:
         - db2
         - oracle
+        - sqlserver
+        - postgres
         - none
       deleteAzureResources:
         description: 'Delete Azure resources at the end'
@@ -19,9 +21,9 @@ on:
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.singleserver
-  # Enable database connection and delete Azure resources at the end. Specify the desired database type (db2, oracle) for parameter "databaseType".
+  # Enable database connection and delete Azure resources at the end. Specify the desired database type (db2, oracle, sqlserver, postgres) for parameter "databaseType".
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"databaseType": "db2"}}'
-  # Enable database connection and keep Azure resources at the end. Specify the desired database type (db2, oracle) for parameter "databaseType".
+  # Enable database connection and keep Azure resources at the end. Specify the desired database type (db2, oracle, sqlserver, postgres) for parameter "databaseType".
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"databaseType": "db2", "deleteAzureResources": "false"}}'
   # Disable database connection and delete Azure resources at the end
   # curl --verbose -XPOST -u "WASdev:${PERSONAL_ACCESS_TOKEN}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/${REPO_NAME}/actions/workflows/integration-test.yaml/dispatches --data '{"ref": "main", "inputs":{"databaseType": "none"}}'
@@ -32,9 +34,9 @@ on:
   # sample request
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.singleserver
-  # Enable database connection and delete Azure resources at the end. Specify the desired database type (db2, oracle) for parameter "databaseType".
+  # Enable database connection and delete Azure resources at the end. Specify the desired database type (db2, oracle, sqlserver, postgres) for parameter "databaseType".
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"databaseType": "db2", "deleteAzureResources": true}}'
-  # Enable database connection and keep Azure resources at the end. Specify the desired database type (db2, oracle) for parameter "databaseType".
+  # Enable database connection and keep Azure resources at the end. Specify the desired database type (db2, oracle, sqlserver, postgres) for parameter "databaseType".
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"databaseType": "db2", "deleteAzureResources": false}}'
   # Disable database connection and delete Azure resources at the end
   # curl --verbose -X POST https://api.github.com/repos/${REPO_NAME}/dispatches -H "Accept: application/vnd.github.everest-preview+json" -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" --data '{"event_type": "integration-test", "client_payload": {"databaseType": "none", "deleteAzureResources": true}}'
@@ -47,9 +49,11 @@ env:
   msTeamsWebhook: ${{ secrets.MSTEAMS_WEBHOOK }}
   vmAdminId: ${{ secrets.VM_ADMIN_ID }}
   vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
-  dbVmName: db${{ github.run_id }}${{ github.run_number }}
+  dbInstanceName: db${{ github.run_id }}${{ github.run_number }}
   db2inst1Password: ${{ secrets.DB2INST1_PASSWORD }}
   oracleDBPassword: ${{ secrets.ORACLE_DB_PASSWORD }}
+  sqlserverDBPassword: ${{ secrets.SQLSERVER_DB_PASSWORD }}
+  postgresqlDBPassword: ${{ secrets.POSTGRESQL_DB_PASSWORD }}
   testResourceGroup: twasSingleTestRG${{ github.run_id }}${{ github.run_number }}
   testDeploymentName: twasSingleTestDeployment${{ github.run_id }}${{ github.run_number }}
   location: eastus
@@ -104,16 +108,16 @@ jobs:
         run: |
           az group create -n ${{ env.testResourceGroup }} -l ${{ env.location }}
           az vm create \
-            --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbVmName }} \
+            --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
             --image "Canonical:UbuntuServer:18.04-LTS:latest" \
             --admin-username azureuser --generate-ssh-keys \
             --nsg-rule NONE --enable-agent true \
-            --vnet-name ${{ env.dbVmName }}VNET --enable-auto-update false \
+            --vnet-name ${{ env.dbInstanceName }}VNET --enable-auto-update false \
             --tags SkipASMAzSecPack=true SkipNRMSCorp=true SkipNRMSDatabricks=true SkipNRMSDB=true SkipNRMSHigh=true SkipNRMSMedium=true SkipNRMSRDPSSH=true SkipNRMSSAW=true SkipNRMSMgmt=true
-          az vm open-port -g ${{ env.testResourceGroup }} -n ${{ env.dbVmName }} --port 50000 --priority 100
+          az vm open-port -g ${{ env.testResourceGroup }} -n ${{ env.dbInstanceName }} --port 50000 --priority 100
           az vm extension set --name CustomScript \
             --extension-instance-name install-db2-in-docker \
-            --resource-group ${{ env.testResourceGroup }} --vm-name ${{ env.dbVmName }} \
+            --resource-group ${{ env.testResourceGroup }} --vm-name ${{ env.dbInstanceName }} \
             --publisher Microsoft.Azure.Extensions --version 2.0 \
             --settings "{\"fileUris\": [\"${{ env.scriptLocation }}install-db2.sh\"]}" \
             --protected-settings "{\"commandToExecute\":\"bash install-db2.sh ${{ env.db2inst1Password }}\"}"
@@ -122,51 +126,95 @@ jobs:
         run: |
           az group create -n ${{ env.testResourceGroup }} -l ${{ env.location }}
           az vm create \
-            --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbVmName }} \
+            --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
             --image Oracle:oracle-database-19-3:oracle-database-19-0904:latest --size Standard_DS2_v2 \
             --admin-username azureuser --generate-ssh-keys \
             --nsg-rule NONE --enable-agent true \
-            --vnet-name ${{ env.dbVmName }}VNET --enable-auto-update false \
+            --vnet-name ${{ env.dbInstanceName }}VNET --enable-auto-update false \
             --tags SkipASMAzSecPack=true SkipNRMSCorp=true SkipNRMSDatabricks=true SkipNRMSDB=true SkipNRMSHigh=true SkipNRMSMedium=true SkipNRMSRDPSSH=true SkipNRMSSAW=true SkipNRMSMgmt=true
-          az vm disk attach --name oradata01 --new --resource-group ${{ env.testResourceGroup }} --vm-name ${{ env.dbVmName }} --size-gb 64 --sku StandardSSD_LRS
-          az vm open-port -g ${{ env.testResourceGroup }} -n ${{ env.dbVmName }} --port 1521,5502 --priority 100
+          az vm disk attach --name oradata01 --new --resource-group ${{ env.testResourceGroup }} --vm-name ${{ env.dbInstanceName }} --size-gb 64 --sku StandardSSD_LRS
+          az vm open-port -g ${{ env.testResourceGroup }} -n ${{ env.dbInstanceName }} --port 1521,5502 --priority 100
           az vm extension set --name CustomScript \
             --extension-instance-name install-oracle \
-            --resource-group ${{ env.testResourceGroup }} --vm-name ${{ env.dbVmName }} \
+            --resource-group ${{ env.testResourceGroup }} --vm-name ${{ env.dbInstanceName }} \
             --publisher Microsoft.Azure.Extensions --version 2.0 \
             --settings "{\"fileUris\": [\"${{ env.scriptLocation }}install-oracle-main.sh\", \"${{ env.scriptLocation }}install-oracle.sh\"]}" \
-            --protected-settings "{\"commandToExecute\":\"bash install-oracle-main.sh ${{ env.oracleDBPassword }}\"}"           
+            --protected-settings "{\"commandToExecute\":\"bash install-oracle-main.sh ${{ env.oracleDBPassword }}\"}"
+      - name: Deploy an instance of Azure SQL Database
+        if: ${{ inputs.databaseType == 'sqlserver' || github.event.client_payload.databaseType == 'sqlserver' }}
+        run: |
+          az group create -n ${{ env.testResourceGroup }} -l ${{ env.location }}
+          az sql server create \
+            --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
+            --admin-user testuser --admin-password ${{ env.sqlserverDBPassword }} \
+            --location ${{ env.location }}
+          host=$(az sql server show \
+            --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
+            --query "fullyQualifiedDomainName" -o tsv)
+          echo "sqlserverHost=${host}" >> $GITHUB_ENV
+          # Allow Azure services to access
+          az sql server firewall-rule create \
+            --resource-group ${{ env.testResourceGroup }} --server ${{ env.dbInstanceName }} \
+            --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+          az sql db create --resource-group ${{ env.testResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
+      - name: Deploy an instance of Azure Database for PostgreSQL
+        if: ${{ inputs.databaseType == 'postgres' || github.event.client_payload.databaseType == 'postgres' }}
+        run: |
+          az group create -n ${{ env.testResourceGroup }} -l ${{ env.location }}
+          az postgres server create \
+            --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
+            --admin-user testuser --admin-password ${{ env.postgresqlDBPassword }} \
+            --location ${{ env.location }}
+          host=$(az postgres server show \
+            --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
+            --query "fullyQualifiedDomainName" -o tsv)
+          echo "postgresqlHost=${host}" >> $GITHUB_ENV
+          # Allow Azure services to access
+          az postgres server firewall-rule create \
+            --resource-group ${{ env.testResourceGroup }} --server ${{ env.dbInstanceName }} \
+            --name "AllowAllAzureIps" --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0
+          az postgres db create --resource-group ${{ env.testResourceGroup }} --server ${{ env.dbInstanceName }} --name testdb
       - name: Build ${{ env.repoName }}
         run: |
-          cd ${{ env.repoName }}
-          if ${{ inputs.databaseType == 'db2' || github.event.client_payload.databaseType == 'db2' || inputs.databaseType == 'oracle' || github.event.client_payload.databaseType == 'oracle' }}; then
-            dbVmPublicIP=$(az vm show \
-              --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbVmName }} \
-              --show-details --query publicIps -o tsv)
+          enableDB=false
+          databaseType=db2
+          dsConnectionURL=jdbc:db2://contoso.db2.database:50000/sample
+          dbUser=contosoDbUser
+          dbPassword=contosoDbPwd
+          if ${{ inputs.databaseType == 'db2' || github.event.client_payload.databaseType == 'db2' }}; then
+            enableDB=true
             databaseType=db2
-            dsConnectionURL=jdbc:db2://${dbVmPublicIP}:50000/sample
+            publicIp=$(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.dbInstanceName }} -d --query publicIps -o tsv)
+            dsConnectionURL=jdbc:db2://${publicIp}:50000/sample
             dbUser=db2inst1
             dbPassword=${{ env.db2inst1Password }}
-            if ${{ inputs.databaseType == 'oracle' || github.event.client_payload.databaseType == 'oracle' }}; then
-              databaseType=oracle
-              dsConnectionURL=jdbc:oracle:thin:@${dbVmPublicIP}:1521/oratest1
-              dbUser=testuser
-              dbPassword=${{ env.oracleDBPassword }}
-            fi
-            mvn -Dgit.repo=${{ env.userName }} -Dgit.tag=$GITHUB_REF_NAME -DuseTrial=true \
-              -DvmSize=Standard_D2_v3 -DdnsLabelPrefix=was \
-              -DadminUsername=${{ env.vmAdminId }} -DadminPasswordOrKey=${{ env.vmAdminPassword }} \
-              -DauthenticationType=password -DwasUsername=${{ env.vmAdminId }} -DwasPassword=${{ env.vmAdminPassword }} \
-              -DenableDB=true -DdatabaseType=${databaseType} -DjdbcDataSourceJNDIName=jdbc/WebSphereCafeDB -DdsConnectionURL=${dsConnectionURL} -DdbUser=${dbUser} -DdbPassword=${dbPassword} \
-              -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
-          else
-            mvn -Dgit.repo=${{ env.userName }} -Dgit.tag=$GITHUB_REF_NAME -DuseTrial=true \
-              -DvmSize=Standard_D2_v3 -DdnsLabelPrefix=was \
-              -DadminUsername=${{ env.vmAdminId }} -DadminPasswordOrKey=${{ env.vmAdminPassword }} \
-              -DauthenticationType=password -DwasUsername=${{ env.vmAdminId }} -DwasPassword=${{ env.vmAdminPassword }} \
-              -DenableDB=false -DdatabaseType=db2 \
-              -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+          elif ${{ inputs.databaseType == 'oracle' || github.event.client_payload.databaseType == 'oracle' }}; then
+            enableDB=true
+            databaseType=oracle
+            publicIp=$(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.dbInstanceName }} -d --query publicIps -o tsv)
+            dsConnectionURL=jdbc:oracle:thin:@${publicIp}:1521/oratest1
+            dbUser=testuser
+            dbPassword=${{ env.oracleDBPassword }}
+          elif ${{ inputs.databaseType == 'sqlserver' || github.event.client_payload.databaseType == 'sqlserver' }}; then
+            enableDB=true
+            databaseType=sqlserver
+            dsConnectionURL="jdbc:sqlserver://${{ env.sqlserverHost }}:1433;database=testdb"
+            dbUser=testuser@${{ env.dbInstanceName }}
+            dbPassword=${{ env.sqlserverDBPassword }}
+          elif ${{ inputs.databaseType == 'postgres' || github.event.client_payload.databaseType == 'postgres' }}; then
+            enableDB=true
+            databaseType=postgres
+            dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"
+            dbUser=testuser@${{ env.dbInstanceName }}
+            dbPassword=${{ env.postgresqlDBPassword }}
           fi
+          cd ${{ env.repoName }}
+          mvn -Dgit.repo=${{ env.userName }} -Dgit.tag=$GITHUB_REF_NAME -DuseTrial=true \
+            -DvmSize=Standard_D2_v3 -DdnsLabelPrefix=was \
+            -DadminUsername=${{ env.vmAdminId }} -DadminPasswordOrKey=${{ env.vmAdminPassword }} \
+            -DauthenticationType=password -DwasUsername=${{ env.vmAdminId }} -DwasPassword=${{ env.vmAdminPassword }} \
+            -DenableDB=${enableDB} -DdatabaseType=${databaseType} -DjdbcDataSourceJNDIName=jdbc/WebSphereCafeDB -DdsConnectionURL=${dsConnectionURL} -DdbUser=${dbUser} -DdbPassword=${dbPassword} \
+            -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
       - name: Deploy a twas-single server on Azure VM
         run: |
           cd ${{ env.repoName }}/target/cli

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -50,10 +50,7 @@ env:
   vmAdminId: ${{ secrets.VM_ADMIN_ID }}
   vmAdminPassword: ${{ secrets.VM_ADMIN_PASSWORD }}
   dbInstanceName: db${{ github.run_id }}${{ github.run_number }}
-  db2inst1Password: ${{ secrets.DB2INST1_PASSWORD }}
-  oracleDBPassword: ${{ secrets.ORACLE_DB_PASSWORD }}
-  sqlserverDBPassword: ${{ secrets.SQLSERVER_DB_PASSWORD }}
-  postgresqlDBPassword: ${{ secrets.POSTGRESQL_DB_PASSWORD }}
+  dbPassword: ${{ secrets.DATABASE_PASSWORD }}
   testResourceGroup: twasSingleTestRG${{ github.run_id }}${{ github.run_number }}
   testDeploymentName: twasSingleTestDeployment${{ github.run_id }}${{ github.run_number }}
   location: eastus
@@ -180,40 +177,35 @@ jobs:
           databaseType=db2
           dsConnectionURL=jdbc:db2://contoso.db2.database:50000/sample
           dbUser=contosoDbUser
-          dbPassword=contosoDbPwd
           if ${{ inputs.databaseType == 'db2' || github.event.client_payload.databaseType == 'db2' }}; then
             enableDB=true
             databaseType=db2
             publicIp=$(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.dbInstanceName }} -d --query publicIps -o tsv)
             dsConnectionURL=jdbc:db2://${publicIp}:50000/sample
             dbUser=db2inst1
-            dbPassword=${{ env.db2inst1Password }}
           elif ${{ inputs.databaseType == 'oracle' || github.event.client_payload.databaseType == 'oracle' }}; then
             enableDB=true
             databaseType=oracle
             publicIp=$(az vm show -g ${{ env.testResourceGroup }} -n ${{ env.dbInstanceName }} -d --query publicIps -o tsv)
             dsConnectionURL=jdbc:oracle:thin:@${publicIp}:1521/oratest1
             dbUser=testuser
-            dbPassword=${{ env.oracleDBPassword }}
           elif ${{ inputs.databaseType == 'sqlserver' || github.event.client_payload.databaseType == 'sqlserver' }}; then
             enableDB=true
             databaseType=sqlserver
             dsConnectionURL="jdbc:sqlserver://${{ env.sqlserverHost }}:1433;database=testdb"
             dbUser=testuser@${{ env.dbInstanceName }}
-            dbPassword=${{ env.sqlserverDBPassword }}
           elif ${{ inputs.databaseType == 'postgres' || github.event.client_payload.databaseType == 'postgres' }}; then
             enableDB=true
             databaseType=postgres
             dsConnectionURL="jdbc:postgresql://${{ env.postgresqlHost }}:5432/testdb"
             dbUser=testuser@${{ env.dbInstanceName }}
-            dbPassword=${{ env.postgresqlDBPassword }}
           fi
           cd ${{ env.repoName }}
           mvn -Dgit.repo=${{ env.userName }} -Dgit.tag=$GITHUB_REF_NAME -DuseTrial=true \
             -DvmSize=Standard_D2_v3 -DdnsLabelPrefix=was \
             -DadminUsername=${{ env.vmAdminId }} -DadminPasswordOrKey=${{ env.vmAdminPassword }} \
             -DauthenticationType=password -DwasUsername=${{ env.vmAdminId }} -DwasPassword=${{ env.vmAdminPassword }} \
-            -DenableDB=${enableDB} -DdatabaseType=${databaseType} -DjdbcDataSourceJNDIName=jdbc/WebSphereCafeDB -DdsConnectionURL=${dsConnectionURL} -DdbUser=${dbUser} -DdbPassword=${dbPassword} \
+            -DenableDB=${enableDB} -DdatabaseType=${databaseType} -DjdbcDataSourceJNDIName=jdbc/WebSphereCafeDB -DdsConnectionURL=${dsConnectionURL} -DdbUser=${dbUser} -DdbPassword=${{ env.dbPassword }} \
             -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
       - name: Deploy a twas-single server on Azure VM
         run: |

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -117,7 +117,7 @@ jobs:
             --resource-group ${{ env.testResourceGroup }} --vm-name ${{ env.dbInstanceName }} \
             --publisher Microsoft.Azure.Extensions --version 2.0 \
             --settings "{\"fileUris\": [\"${{ env.scriptLocation }}install-db2.sh\"]}" \
-            --protected-settings "{\"commandToExecute\":\"bash install-db2.sh ${{ env.db2inst1Password }}\"}"
+            --protected-settings "{\"commandToExecute\":\"bash install-db2.sh ${{ env.dbPassword }}\"}"
       - name: Deploy an Oracle database server on Azure VM
         if: ${{ inputs.databaseType == 'oracle' || github.event.client_payload.databaseType == 'oracle' }}
         run: |
@@ -136,14 +136,14 @@ jobs:
             --resource-group ${{ env.testResourceGroup }} --vm-name ${{ env.dbInstanceName }} \
             --publisher Microsoft.Azure.Extensions --version 2.0 \
             --settings "{\"fileUris\": [\"${{ env.scriptLocation }}install-oracle-main.sh\", \"${{ env.scriptLocation }}install-oracle.sh\"]}" \
-            --protected-settings "{\"commandToExecute\":\"bash install-oracle-main.sh ${{ env.oracleDBPassword }}\"}"
+            --protected-settings "{\"commandToExecute\":\"bash install-oracle-main.sh ${{ env.dbPassword }}\"}"
       - name: Deploy an instance of Azure SQL Database
         if: ${{ inputs.databaseType == 'sqlserver' || github.event.client_payload.databaseType == 'sqlserver' }}
         run: |
           az group create -n ${{ env.testResourceGroup }} -l ${{ env.location }}
           az sql server create \
             --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
-            --admin-user testuser --admin-password ${{ env.sqlserverDBPassword }} \
+            --admin-user testuser --admin-password ${{ env.dbPassword }} \
             --location ${{ env.location }}
           host=$(az sql server show \
             --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
@@ -160,7 +160,7 @@ jobs:
           az group create -n ${{ env.testResourceGroup }} -l ${{ env.location }}
           az postgres server create \
             --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \
-            --admin-user testuser --admin-password ${{ env.postgresqlDBPassword }} \
+            --admin-user testuser --admin-password ${{ env.dbPassword }} \
             --location ${{ env.location }}
           host=$(az postgres server show \
             --resource-group ${{ env.testResourceGroup }} --name ${{ env.dbInstanceName }} \

--- a/.github/workflows/setup-credentials.sh
+++ b/.github/workflows/setup-credentials.sh
@@ -35,6 +35,10 @@ VM_ADMIN_PASSWORD=
 DB2INST1_PASSWORD=
 # Password for Oracle database user testuser
 ORACLE_DB_PASSWORD=
+# Password for Microsoft SQL Server database user testuser
+SQLSERVER_DB_PASSWORD=
+# Password for PostgreSQL database user testuser
+POSTGRESQL_DB_PASSWORD=
 # Optional: Web hook for Microsoft Teams channel
 MSTEAMS_WEBHOOK=
 
@@ -109,6 +113,16 @@ if [ "$ORACLE_DB_PASSWORD" == '' ] ; then
     read -r -p "Enter password for Oracle database user testuser: " ORACLE_DB_PASSWORD
 fi
 
+# get SQLSERVER_DB_PASSWORD if not set at the beginning of this file
+if [ "$SQLSERVER_DB_PASSWORD" == '' ] ; then
+    read -r -p "Enter password for Microsoft SQL Server database user testuser: " SQLSERVER_DB_PASSWORD
+fi
+
+# get POSTGRESQL_DB_PASSWORD if not set at the beginning of this file
+if [ "$POSTGRESQL_DB_PASSWORD" == '' ] ; then
+    read -r -p "Enter password for PostgreSQL database user testuser: " POSTGRESQL_DB_PASSWORD
+fi
+
 # Optional: get MSTEAMS_WEBHOOK if not set at the beginning of this file
 if [ "$MSTEAMS_WEBHOOK" == '' ] ; then
     read -r -p "[Optional] Enter Web hook for Microsoft Teams channel, or press 'Enter' to ignore: " MSTEAMS_WEBHOOK
@@ -171,6 +185,8 @@ if $USE_GITHUB_CLI; then
     gh ${GH_FLAGS} secret set VM_ADMIN_PASSWORD -b"${VM_ADMIN_PASSWORD}"
     gh ${GH_FLAGS} secret set DB2INST1_PASSWORD -b"${DB2INST1_PASSWORD}"
     gh ${GH_FLAGS} secret set ORACLE_DB_PASSWORD -b"${ORACLE_DB_PASSWORD}"
+    gh ${GH_FLAGS} secret set SQLSERVER_DB_PASSWORD -b"${SQLSERVER_DB_PASSWORD}"
+    gh ${GH_FLAGS} secret set POSTGRESQL_DB_PASSWORD -b"${POSTGRESQL_DB_PASSWORD}"
     gh ${GH_FLAGS} secret set MSTEAMS_WEBHOOK -b"${MSTEAMS_WEBHOOK}"
     msg "${GREEN}Secrets configured"
   } || {
@@ -195,6 +211,10 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${GREEN}${DB2INST1_PASSWORD}"
   msg "${YELLOW}\"ORACLE_DB_PASSWORD\""
   msg "${GREEN}${ORACLE_DB_PASSWORD}"
+  msg "${YELLOW}\"SQLSERVER_DB_PASSWORD\""
+  msg "${GREEN}${SQLSERVER_DB_PASSWORD}"
+  msg "${YELLOW}\"POSTGRESQL_DB_PASSWORD\""
+  msg "${GREEN}${POSTGRESQL_DB_PASSWORD}"
   msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
   msg "${GREEN}${MSTEAMS_WEBHOOK}"
   msg "${NOFORMAT}========================================================================"

--- a/.github/workflows/setup-credentials.sh
+++ b/.github/workflows/setup-credentials.sh
@@ -31,14 +31,8 @@ OWNER_REPONAME=
 VM_ADMIN_ID=
 # Password for VM/Admin account
 VM_ADMIN_PASSWORD=
-# Password for IBM DB2 database user db2inst1
-DB2INST1_PASSWORD=
-# Password for Oracle database user testuser
-ORACLE_DB_PASSWORD=
-# Password for Microsoft SQL Server database user testuser
-SQLSERVER_DB_PASSWORD=
-# Password for PostgreSQL database user testuser
-POSTGRESQL_DB_PASSWORD=
+# Password for database user db2inst1 (IBM DB2) and testuser (other database types)
+DATABASE_PASSWORD=
 # Optional: Web hook for Microsoft Teams channel
 MSTEAMS_WEBHOOK=
 
@@ -103,24 +97,9 @@ if [ "$VM_ADMIN_PASSWORD" == '' ] ; then
     read -r -p "Enter password for VM/Admin account: " VM_ADMIN_PASSWORD
 fi
 
-# get DB2INST1_PASSWORD if not set at the beginning of this file
-if [ "$DB2INST1_PASSWORD" == '' ] ; then
-    read -r -p "Enter password for IBM DB2 database user db2inst1: " DB2INST1_PASSWORD
-fi
-
-# get ORACLE_DB_PASSWORD if not set at the beginning of this file
-if [ "$ORACLE_DB_PASSWORD" == '' ] ; then
-    read -r -p "Enter password for Oracle database user testuser: " ORACLE_DB_PASSWORD
-fi
-
-# get SQLSERVER_DB_PASSWORD if not set at the beginning of this file
-if [ "$SQLSERVER_DB_PASSWORD" == '' ] ; then
-    read -r -p "Enter password for Microsoft SQL Server database user testuser: " SQLSERVER_DB_PASSWORD
-fi
-
-# get POSTGRESQL_DB_PASSWORD if not set at the beginning of this file
-if [ "$POSTGRESQL_DB_PASSWORD" == '' ] ; then
-    read -r -p "Enter password for PostgreSQL database user testuser: " POSTGRESQL_DB_PASSWORD
+# get DATABASE_PASSWORD if not set at the beginning of this file
+if [ "$DATABASE_PASSWORD" == '' ] ; then
+    read -r -p "Enter password for database user db2inst1 (IBM DB2) and testuser (other database types): " DATABASE_PASSWORD
 fi
 
 # Optional: get MSTEAMS_WEBHOOK if not set at the beginning of this file
@@ -183,10 +162,7 @@ if $USE_GITHUB_CLI; then
     gh ${GH_FLAGS} secret set USER_NAME -b"${USER_NAME}"
     gh ${GH_FLAGS} secret set VM_ADMIN_ID -b"${VM_ADMIN_ID}"
     gh ${GH_FLAGS} secret set VM_ADMIN_PASSWORD -b"${VM_ADMIN_PASSWORD}"
-    gh ${GH_FLAGS} secret set DB2INST1_PASSWORD -b"${DB2INST1_PASSWORD}"
-    gh ${GH_FLAGS} secret set ORACLE_DB_PASSWORD -b"${ORACLE_DB_PASSWORD}"
-    gh ${GH_FLAGS} secret set SQLSERVER_DB_PASSWORD -b"${SQLSERVER_DB_PASSWORD}"
-    gh ${GH_FLAGS} secret set POSTGRESQL_DB_PASSWORD -b"${POSTGRESQL_DB_PASSWORD}"
+    gh ${GH_FLAGS} secret set DATABASE_PASSWORD -b"${DATABASE_PASSWORD}"
     gh ${GH_FLAGS} secret set MSTEAMS_WEBHOOK -b"${MSTEAMS_WEBHOOK}"
     msg "${GREEN}Secrets configured"
   } || {
@@ -207,14 +183,8 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${GREEN}${VM_ADMIN_ID}"
   msg "${YELLOW}\"VM_ADMIN_PASSWORD\""
   msg "${GREEN}${VM_ADMIN_PASSWORD}"
-  msg "${YELLOW}\"DB2INST1_PASSWORD\""
-  msg "${GREEN}${DB2INST1_PASSWORD}"
-  msg "${YELLOW}\"ORACLE_DB_PASSWORD\""
-  msg "${GREEN}${ORACLE_DB_PASSWORD}"
-  msg "${YELLOW}\"SQLSERVER_DB_PASSWORD\""
-  msg "${GREEN}${SQLSERVER_DB_PASSWORD}"
-  msg "${YELLOW}\"POSTGRESQL_DB_PASSWORD\""
-  msg "${GREEN}${POSTGRESQL_DB_PASSWORD}"
+  msg "${YELLOW}\"DATABASE_PASSWORD\""
+  msg "${GREEN}${DATABASE_PASSWORD}"
   msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
   msg "${GREEN}${MSTEAMS_WEBHOOK}"
   msg "${NOFORMAT}========================================================================"

--- a/.github/workflows/tear-down-credentials.sh
+++ b/.github/workflows/tear-down-credentials.sh
@@ -76,10 +76,7 @@ if $USE_GITHUB_CLI; then
     gh ${GH_FLAGS} secret remove USER_NAME
     gh ${GH_FLAGS} secret remove VM_ADMIN_ID
     gh ${GH_FLAGS} secret remove VM_ADMIN_PASSWORD
-    gh ${GH_FLAGS} secret remove DB2INST1_PASSWORD
-    gh ${GH_FLAGS} secret remove ORACLE_DB_PASSWORD
-    gh ${GH_FLAGS} secret remove SQLSERVER_DB_PASSWORD
-    gh ${GH_FLAGS} secret remove POSTGRESQL_DB_PASSWORD
+    gh ${GH_FLAGS} secret remove DATABASE_PASSWORD
     gh ${GH_FLAGS} secret remove MSTEAMS_WEBHOOK
     msg "${GREEN}Secrets removed"
   } || {
@@ -96,10 +93,7 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${YELLOW}\"USER_NAME\""
   msg "${YELLOW}\"VM_ADMIN_ID\""
   msg "${YELLOW}\"VM_ADMIN_PASSWORD\""
-  msg "${YELLOW}\"DB2INST1_PASSWORD\""
-  msg "${YELLOW}\"ORACLE_DB_PASSWORD\""
-  msg "${YELLOW}\"SQLSERVER_DB_PASSWORD\""
-  msg "${YELLOW}\"POSTGRESQL_DB_PASSWORD\""
+  msg "${YELLOW}\"DATABASE_PASSWORD\""
   msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
   msg "${NOFORMAT}========================================================================"
 fi

--- a/.github/workflows/tear-down-credentials.sh
+++ b/.github/workflows/tear-down-credentials.sh
@@ -78,6 +78,8 @@ if $USE_GITHUB_CLI; then
     gh ${GH_FLAGS} secret remove VM_ADMIN_PASSWORD
     gh ${GH_FLAGS} secret remove DB2INST1_PASSWORD
     gh ${GH_FLAGS} secret remove ORACLE_DB_PASSWORD
+    gh ${GH_FLAGS} secret remove SQLSERVER_DB_PASSWORD
+    gh ${GH_FLAGS} secret remove POSTGRESQL_DB_PASSWORD
     gh ${GH_FLAGS} secret remove MSTEAMS_WEBHOOK
     msg "${GREEN}Secrets removed"
   } || {
@@ -96,6 +98,8 @@ if [ $USE_GITHUB_CLI == false ]; then
   msg "${YELLOW}\"VM_ADMIN_PASSWORD\""
   msg "${YELLOW}\"DB2INST1_PASSWORD\""
   msg "${YELLOW}\"ORACLE_DB_PASSWORD\""
+  msg "${YELLOW}\"SQLSERVER_DB_PASSWORD\""
+  msg "${YELLOW}\"POSTGRESQL_DB_PASSWORD\""
   msg "${YELLOW}\"MSTEAMS_WEBHOOK\""
   msg "${NOFORMAT}========================================================================"
 fi

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
 
    ```bash
-   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DuseTrial=true -DvmSize=<vmSize> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -DenableDB=<true|false> -DdatabaseType=<db2|oracle|sqlserver|postgres> -DjdbcDataSourceJNDIName=<jdbcDataSourceJNDIName> -DdsConnectionURL=<dsConnectionURL> -DdbUser=<dbUser> -DdbPassword=<dbPassword> -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DuseTrial=true -DvmSize=<vmSize> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -DenableDB=<true|false> -DdatabaseType=<db2|oracle|sqlserver> -DjdbcDataSourceJNDIName=<jdbcDataSourceJNDIName> -DdsConnectionURL=<dsConnectionURL> -DdbUser=<dbUser> -DdbPassword=<dbPassword> -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
    ```
 
 1. Change to `./target/cli` directory

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 1. Build the project by replacing all placeholder `${<place_holder>}` with valid values
 
    ```bash
-   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DuseTrial=true -DvmSize=<vmSize> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -DenableDB=<true|false> -DdatabaseType=<db2|oracle> -DjdbcDataSourceJNDIName=<jdbcDataSourceJNDIName> -DdsConnectionURL=<dsConnectionURL> -DdbUser=<dbUser> -DdbPassword=<dbPassword> -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
+   mvn -Dgit.repo=<repo_user> -Dgit.tag=<repo_tag> -DuseTrial=true -DvmSize=<vmSize> -DdnsLabelPrefix=<dnsLabelPrefix> -DadminUsername=<adminUsername> -DadminPasswordOrKey=<adminPassword|adminSSHPublicKey> -DauthenticationType=<password|sshPublicKey> -DwasUsername=<wasUsername> -DwasPassword=<wasPassword> -DenableDB=<true|false> -DdatabaseType=<db2|oracle|sqlserver|postgres> -DjdbcDataSourceJNDIName=<jdbcDataSourceJNDIName> -DdsConnectionURL=<dsConnectionURL> -DdbUser=<dbUser> -DdbPassword=<dbPassword> -Dtest.args="-Test All" -Pbicep -Passembly -Ptemplate-validation-tests clean install
    ```
 
 1. Change to `./target/cli` directory

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.singleserver</artifactId>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -360,6 +360,14 @@
                                         {
                                             "label": "Oracle database",
                                             "value": "oracle"
+                                        },
+                                        {
+                                            "label": "Microsoft SQL Server",
+                                            "value": "sqlserver"
+                                        },
+                                        {
+                                            "label": "PostgreSQL",
+                                            "value": "postgres"
                                         }
                                     ],
                                     "required": true
@@ -404,6 +412,32 @@
                                     "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
                                 },
                                 "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle')]"
+                            },
+                            {
+                                "name": "sqlserverDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:sqlserver://&lt;host&gt;:&lt;port&gt;;database=&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:sqlserver:\/\/([^\/]+):([0-9]+);database=([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'sqlserver')]"
+                            },
+                            {
+                                "name": "postgresDsConnectionURL",
+                                "type": "Microsoft.Common.TextBox",
+                                "label": "Data source connection string (jdbc:postgresql://&lt;host&gt;:&lt;port&gt;/&lt;database&gt;)",
+                                "toolTip": "The JDBC connection string for the database",
+                                "defaultValue": "",
+                                "constraints": {
+                                    "required": true,
+                                    "regex": "^jdbc:postgresql:\/\/([^\/]+):([0-9]+)\/([\\w-]+)",
+                                    "validationMessage": "A valid JDBC URL for the chosen database type must be provided"
+                                },
+                                "visible": "[equals(steps('section_database').databaseConnectionInfo.databaseType, 'postgres')]"
                             },
                             {
                                 "name": "dbUser",
@@ -461,7 +495,7 @@
             "enableDB": "[bool(steps('section_database').enableDB)]",
             "databaseType": "[steps('section_database').databaseConnectionInfo.databaseType]",
             "jdbcDataSourceJNDIName": "[steps('section_database').databaseConnectionInfo.jdbcDataSourceJNDIName]",
-            "dsConnectionURL": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle'), steps('section_database').databaseConnectionInfo.oracleDsConnectionURL, steps('section_database').databaseConnectionInfo.db2DsConnectionURL)]",
+            "dsConnectionURL": "[if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'oracle'), steps('section_database').databaseConnectionInfo.oracleDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'sqlserver'), steps('section_database').databaseConnectionInfo.sqlserverDsConnectionURL, if(equals(steps('section_database').databaseConnectionInfo.databaseType, 'postgres'), steps('section_database').databaseConnectionInfo.postgresDsConnectionURL, steps('section_database').databaseConnectionInfo.db2DsConnectionURL)))]",
             "dbUser": "[steps('section_database').databaseConnectionInfo.dbUser]",
             "dbPassword": "[steps('section_database').databaseConnectionInfo.dbPassword]"  
         }

--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -364,10 +364,6 @@
                                         {
                                             "label": "Microsoft SQL Server",
                                             "value": "sqlserver"
-                                        },
-                                        {
-                                            "label": "PostgreSQL",
-                                            "value": "postgres"
                                         }
                                     ],
                                     "required": true

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -91,6 +91,8 @@ param enableDB bool = false
 @allowed([
   'db2'
   'oracle'
+  'sqlserver'
+  'postgres'
 ])
 @description('One of the supported database types')
 param databaseType string = 'db2'
@@ -335,6 +337,8 @@ resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@2022-03-01' =
         uri(const_scriptLocation, 'create-ds.sh${_artifactsLocationSasToken}')
         uri(const_scriptLocation, 'create-ds-db2.py.template${_artifactsLocationSasToken}')
         uri(const_scriptLocation, 'create-ds-oracle.py.template${_artifactsLocationSasToken}')
+        uri(const_scriptLocation, 'create-ds-sqlserver.py.template${_artifactsLocationSasToken}')
+        uri(const_scriptLocation, 'create-ds-postgres.py.template${_artifactsLocationSasToken}')
       ]
     }
     protectedSettings: {

--- a/src/main/scripts/create-ds-postgres.py.template
+++ b/src/main/scripts/create-ds-postgres.py.template
@@ -12,50 +12,44 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# Reference: https://raw.githubusercontent.com/keensoft/was-db2-docker/master/was/assets/create-datasource.jython
-
 # Get WAS server id as the parent ID for creating JDBC provider
 server = AdminConfig.getid('/Server:${WAS_SERVER_NAME}/')
 
 # JDBC Provider
-n1 = ['name', 'DB2JDBCProvider']
-implCN = ['implementationClassName', 'com.ibm.db2.jcc.DB2XADataSource']
-cls = ['classpath', '${DB2UNIVERSAL_JDBC_DRIVER_PATH}/db2jcc.jar;${DB2UNIVERSAL_JDBC_DRIVER_PATH}/db2jcc_license_cu.jar;${DB2UNIVERSAL_JDBC_DRIVER_PATH}/db2jcc_license_cisuz.jar']
-provider = ['providerType', 'DB2 Universal JDBC Driver Provider (XA)']
-xa = ['xa', 'true']
-jdbcAttrs = [n1,  implCN, cls, provider, xa]
+n1 = ['name', 'PostgreSQLJDBCProvider']
+implCN = ['implementationClassName', 'org.postgresql.ds.PGConnectionPoolDataSource']
+cls = ['classpath', '${POSTGRESQL_JDBC_DRIVER_CLASS_PATH}']
+provider = ['providerType', 'User-defined JDBC Provider']
+jdbcAttrs = [n1,  implCN, cls, provider]
 jdbCProvider = AdminConfig.create('JDBCProvider', server, jdbcAttrs)
 
 # JASS Auth entry
-userAlias = 'wasbase/db2'
+userAlias = 'wasbase/postgres'
 alias = ['alias', userAlias]
-userid = ['userId', '${DB2_DATABASE_USER_NAME}']
-password = ['password', '${DB2_DATABASE_USER_PASSWORD}']
+userid = ['userId', '${POSTGRESQL_DATABASE_USER_NAME}']
+password = ['password', '${POSTGRESQL_DATABASE_USER_PASSWORD}']
 jaasAttrs = [alias, userid, password]
 security = AdminConfig.getid('/Security:/')
 j2cUser = AdminConfig.create('JAASAuthData', security, jaasAttrs)
 
 # Data Source
-newjdbc = AdminConfig.getid('/JDBCProvider:DB2JDBCProvider/')
-name = ['name', '${DB2_DATASOURCE_NAME}']
-jndi = ['jndiName', '${DB2_DATASOURCE_JNDI_NAME}']
+newjdbc = AdminConfig.getid('/JDBCProvider:PostgreSQLJDBCProvider/')
+name = ['name', '${POSTGRESQL_DATASOURCE_NAME}']
+jndi = ['jndiName', '${POSTGRESQL_DATASOURCE_JNDI_NAME}']
 auth = ['authDataAlias', userAlias]
 authMechanism = ['authMechanismPreference', 'BASIC_PASSWORD']
-helper = ['datasourceHelperClassname', 'com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper']
+helper = ['datasourceHelperClassname', 'com.ibm.websphere.rsadapter.GenericDataStoreHelper']
 dsAttrs = [name, jndi, auth, authMechanism, helper]
 newds = AdminConfig.create('DataSource', newjdbc, dsAttrs)
 
 # Data Source properties
 propSet = AdminConfig.create('J2EEResourcePropertySet', newds, [])
-AdminConfig.create('J2EEResourceProperty', propSet, [["name", "driverType"], ["value", "4"]])
-AdminConfig.create('J2EEResourceProperty', propSet, [["name", "databaseName"], ["value", "${DB2_DATABASE_NAME}"]])
-AdminConfig.create('J2EEResourceProperty', propSet, [["name", "serverName"], ["value", "${DB2_SERVER_NAME}"]])
-AdminConfig.create('J2EEResourceProperty', propSet, [["name", "portNumber"], ["value", "${DB2_PORT_NUMBER}"]])
+AdminConfig.create('J2EEResourceProperty', propSet, [["name", "URL"], ["value", "${POSTGRESQL_DATABASE_URL}"]])
 
 # Create CMP Connection factory
 rra = AdminConfig.getid("/Server:${WAS_SERVER_NAME}/J2CResourceAdapter:WebSphere Relational Resource Adapter/")
 cmpAttrs = []
-cmpAttrs.append(["name", "DB2DataSource_CF"])
+cmpAttrs.append(["name", "PostgreSQLDataSource_CF"])
 cmpAttrs.append(["authMechanismPreference", "BASIC_PASSWORD"])
 cmpAttrs.append(["authDataAlias", userAlias])
 cmpAttrs.append(["cmpDatasource", newds])

--- a/src/main/scripts/create-ds-sqlserver.py.template
+++ b/src/main/scripts/create-ds-sqlserver.py.template
@@ -12,50 +12,46 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-# Reference: https://raw.githubusercontent.com/keensoft/was-db2-docker/master/was/assets/create-datasource.jython
-
 # Get WAS server id as the parent ID for creating JDBC provider
 server = AdminConfig.getid('/Server:${WAS_SERVER_NAME}/')
 
 # JDBC Provider
-n1 = ['name', 'DB2JDBCProvider']
-implCN = ['implementationClassName', 'com.ibm.db2.jcc.DB2XADataSource']
-cls = ['classpath', '${DB2UNIVERSAL_JDBC_DRIVER_PATH}/db2jcc.jar;${DB2UNIVERSAL_JDBC_DRIVER_PATH}/db2jcc_license_cu.jar;${DB2UNIVERSAL_JDBC_DRIVER_PATH}/db2jcc_license_cisuz.jar']
-provider = ['providerType', 'DB2 Universal JDBC Driver Provider (XA)']
-xa = ['xa', 'true']
-jdbcAttrs = [n1,  implCN, cls, provider, xa]
+n1 = ['name', 'SQLServerJDBCProvider']
+implCN = ['implementationClassName', 'com.microsoft.sqlserver.jdbc.SQLServerConnectionPoolDataSource']
+cls = ['classpath', '${SQLSERVER_JDBC_DRIVER_CLASS_PATH}']
+provider = ['providerType', 'Microsoft SQL Server JDBC Driver']
+jdbcAttrs = [n1,  implCN, cls, provider]
 jdbCProvider = AdminConfig.create('JDBCProvider', server, jdbcAttrs)
 
 # JASS Auth entry
-userAlias = 'wasbase/db2'
+userAlias = 'wasbase/sqlserver'
 alias = ['alias', userAlias]
-userid = ['userId', '${DB2_DATABASE_USER_NAME}']
-password = ['password', '${DB2_DATABASE_USER_PASSWORD}']
+userid = ['userId', '${SQLSERVER_DATABASE_USER_NAME}']
+password = ['password', '${SQLSERVER_DATABASE_USER_PASSWORD}']
 jaasAttrs = [alias, userid, password]
 security = AdminConfig.getid('/Security:/')
 j2cUser = AdminConfig.create('JAASAuthData', security, jaasAttrs)
 
 # Data Source
-newjdbc = AdminConfig.getid('/JDBCProvider:DB2JDBCProvider/')
-name = ['name', '${DB2_DATASOURCE_NAME}']
-jndi = ['jndiName', '${DB2_DATASOURCE_JNDI_NAME}']
+newjdbc = AdminConfig.getid('/JDBCProvider:SQLServerJDBCProvider/')
+name = ['name', '${SQLSERVER_DATASOURCE_NAME}']
+jndi = ['jndiName', '${SQLSERVER_DATASOURCE_JNDI_NAME}']
 auth = ['authDataAlias', userAlias]
 authMechanism = ['authMechanismPreference', 'BASIC_PASSWORD']
-helper = ['datasourceHelperClassname', 'com.ibm.websphere.rsadapter.DB2UniversalDataStoreHelper']
+helper = ['datasourceHelperClassname', 'com.ibm.websphere.rsadapter.MicrosoftSQLServerDataStoreHelper']
 dsAttrs = [name, jndi, auth, authMechanism, helper]
 newds = AdminConfig.create('DataSource', newjdbc, dsAttrs)
 
 # Data Source properties
 propSet = AdminConfig.create('J2EEResourcePropertySet', newds, [])
-AdminConfig.create('J2EEResourceProperty', propSet, [["name", "driverType"], ["value", "4"]])
-AdminConfig.create('J2EEResourceProperty', propSet, [["name", "databaseName"], ["value", "${DB2_DATABASE_NAME}"]])
-AdminConfig.create('J2EEResourceProperty', propSet, [["name", "serverName"], ["value", "${DB2_SERVER_NAME}"]])
-AdminConfig.create('J2EEResourceProperty', propSet, [["name", "portNumber"], ["value", "${DB2_PORT_NUMBER}"]])
+AdminConfig.create('J2EEResourceProperty', propSet, [["name", "databaseName"], ["value", "${SQLSERVER_DATABASE_NAME}"]])
+AdminConfig.create('J2EEResourceProperty', propSet, [["name", "serverName"], ["value", "${SQLSERVER_SERVER_NAME}"]])
+AdminConfig.create('J2EEResourceProperty', propSet, [["name", "portNumber"], ["value", "${SQLSERVER_PORT_NUMBER}"]])
 
 # Create CMP Connection factory
 rra = AdminConfig.getid("/Server:${WAS_SERVER_NAME}/J2CResourceAdapter:WebSphere Relational Resource Adapter/")
 cmpAttrs = []
-cmpAttrs.append(["name", "DB2DataSource_CF"])
+cmpAttrs.append(["name", "SQLServerDataSource_CF"])
 cmpAttrs.append(["authMechanismPreference", "BASIC_PASSWORD"])
 cmpAttrs.append(["authDataAlias", userAlias])
 cmpAttrs.append(["cmpDatasource", newds])

--- a/src/main/scripts/create-ds.sh
+++ b/src/main/scripts/create-ds.sh
@@ -39,7 +39,7 @@ retryMaxAttempt=5
 
 if [ $dbType == "db2" ]; then
     regex="^jdbc:db2://([^/]+):([0-9]+)/([[:alnum:]_-]+)"
-    if [[ $dsConnectionString =~ $regex ]]; then 
+    if [[ "$dsConnectionString" =~ $regex ]]; then 
         db2ServerName="${BASH_REMATCH[1]}"
         db2ServerPortNumber="${BASH_REMATCH[2]}"
         db2DBName="${BASH_REMATCH[3]}"
@@ -61,7 +61,7 @@ if [ $dbType == "db2" ]; then
     sed -i "s/\${DB2_DATASOURCE_NAME}/${jdbcDataSourceName}/g" $createDsScript
     sed -i "s#\${DB2_DATASOURCE_JNDI_NAME}#${jdbcDSJNDIName}#g" $createDsScript
     sed -i "s/\${DB2_SERVER_NAME}/${db2ServerName}/g" $createDsScript
-    sed -i "s/\${PORT_NUMBER}/${db2ServerPortNumber}/g" $createDsScript
+    sed -i "s/\${DB2_PORT_NUMBER}/${db2ServerPortNumber}/g" $createDsScript
 elif [ $dbType == "oracle" ]; then
     # Download jdbc drivers
     curl --retry ${retryMaxAttempt} -Lo ${jdbcDriverPath}/ojdbc8.jar https://download.oracle.com/otn-pub/otn_software/jdbc/1916/ojdbc8.jar
@@ -75,6 +75,44 @@ elif [ $dbType == "oracle" ]; then
     sed -i "s/\${ORACLE_DATASOURCE_NAME}/${jdbcDataSourceName}/g" $createDsScript
     sed -i "s#\${ORACLE_DATASOURCE_JNDI_NAME}#${jdbcDSJNDIName}#g" $createDsScript
     sed -i "s#\${ORACLE_DATABASE_URL}#${dsConnectionString}#g" $createDsScript
+elif [ $dbType == "sqlserver" ]; then
+    regex="^jdbc:sqlserver://([^/]+):([0-9]+);database=([[:alnum:]_-]+)"
+    if [[ "$dsConnectionString" =~ $regex ]]; then 
+        sqlServerServerName="${BASH_REMATCH[1]}"
+        sqlServerPortNumber="${BASH_REMATCH[2]}"
+        sqlServerDBName="${BASH_REMATCH[3]}"
+    else
+        echo "$dsConnectionString doesn't match the required format of Microsoft SQL Server data source connection string."
+        exit 1
+    fi
+
+    # Download jdbc drivers
+    curl --retry ${retryMaxAttempt} -Lo ${jdbcDriverPath}/mssql-jdbc-11.2.1.jre8.jar https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/11.2.1.jre8/mssql-jdbc-11.2.1.jre8.jar
+    jdbcDriverClassPath=$(realpath "$jdbcDriverPath"/mssql-jdbc-11.2.1.jre8.jar)
+
+    # Replace placeholder strings with user-input parameters
+    sed -i "s/\${WAS_SERVER_NAME}/${wasServerName}/g" $createDsScript
+    sed -i "s#\${SQLSERVER_JDBC_DRIVER_CLASS_PATH}#${jdbcDriverClassPath}#g" $createDsScript
+    sed -i "s/\${SQLSERVER_DATABASE_USER_NAME}/${databaseUser}/g" $createDsScript
+    sed -i "s/\${SQLSERVER_DATABASE_USER_PASSWORD}/${databasePassword}/g" $createDsScript
+    sed -i "s/\${SQLSERVER_DATABASE_NAME}/${sqlServerDBName}/g" $createDsScript
+    sed -i "s/\${SQLSERVER_DATASOURCE_NAME}/${jdbcDataSourceName}/g" $createDsScript
+    sed -i "s#\${SQLSERVER_DATASOURCE_JNDI_NAME}#${jdbcDSJNDIName}#g" $createDsScript
+    sed -i "s/\${SQLSERVER_SERVER_NAME}/${sqlServerServerName}/g" $createDsScript
+    sed -i "s/\${SQLSERVER_PORT_NUMBER}/${sqlServerPortNumber}/g" $createDsScript
+elif [ $dbType == "postgres" ]; then
+    # Download jdbc drivers
+    curl --retry ${retryMaxAttempt} -Lo ${jdbcDriverPath}/postgresql-42.5.0.jar https://jdbc.postgresql.org/download/postgresql-42.5.0.jar
+    jdbcDriverClassPath=$(realpath "$jdbcDriverPath"/postgresql-42.5.0.jar)
+
+    # Replace placeholder strings with user-input parameters
+    sed -i "s/\${WAS_SERVER_NAME}/${wasServerName}/g" $createDsScript
+    sed -i "s#\${POSTGRESQL_JDBC_DRIVER_CLASS_PATH}#${jdbcDriverClassPath}#g" $createDsScript
+    sed -i "s/\${POSTGRESQL_DATABASE_USER_NAME}/${databaseUser}/g" $createDsScript
+    sed -i "s/\${POSTGRESQL_DATABASE_USER_PASSWORD}/${databasePassword}/g" $createDsScript
+    sed -i "s/\${POSTGRESQL_DATASOURCE_NAME}/${jdbcDataSourceName}/g" $createDsScript
+    sed -i "s#\${POSTGRESQL_DATASOURCE_JNDI_NAME}#${jdbcDSJNDIName}#g" $createDsScript
+    sed -i "s#\${POSTGRESQL_DATABASE_URL}#${dsConnectionString}#g" $createDsScript
 fi
 
 # Create JDBC provider and data source using jython file


### PR DESCRIPTION
## Description

The PR is to resolve the following issues:
* Resolve #57 

## Change summary

* Add two new database type **Microsoft SQL Server** blade **Database**.
* Update template to handle Microsoft SQL Server database connection.
* Add new scripts to create Microsoft SQL Server JDBC providers and data sources.
* Update the main `install.sh` to handle the Microsoft SQL Server database connection.
* Update the `integration-test` pipeline to support Microsoft SQL Server database connection.
* Update setup and tear-down scripts to handle the new GitHub action secret `DATABASE_PASSWORD` 

## Testing

Verified the following 4 test cases with `integration-test` pipeline:
* Microsoft SQL Server database enabled: [integration-test-111](https://github.com/majguo/azure.websphere-traditional.singleserver/actions/runs/3506583153)
* Oracle database enabled: [integration-test-112](https://github.com/majguo/azure.websphere-traditional.singleserver/actions/runs/3506584401)
* Db2 database enabled: [integration-test-113](https://github.com/majguo/azure.websphere-traditional.singleserver/actions/runs/3506584892)
* Database connection disabled: [integration-test-109](https://github.com/majguo/azure.websphere-traditional.singleserver/actions/runs/3505707186)

If you want to enable Microsoft SQL Server and PostgreSQL database connection in `integration-test` pipeline, pls look at #59.

Verified the following 4 test cases using the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwas-single-server):
* Microsoft SQL Server database enabled
* Oracle database enabled
* Db2 database enabled
* Database connection disabled

Feel free to do a live testing with the [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwas-single-server).

## UI changes review

Besides visiting [preview link](https://portal.azure.com/?feature.customportal=false#create/microsoft_javaeeonazure_test.20191212-arm-rhel-was-nd-v9-cluster-previewwas-single-server) for reviewing the new database type `Oracle database` in blade `Database`, reviewer can preview the UI changes using the **Create UI Definition Sandbox**:

- Open [Create UI Definition Sandbox](https://portal.azure.com/?feature.customPortal=false#blade/Microsoft_Azure_CreateUIDef/SandboxBlade) in a new tab of browser.
- Open UI source code [createUiDefinition.json](https://raw.githubusercontent.com/majguo/azure.websphere-traditional.singleserver/mssqlserver-postgres-db-conn/src/main/arm/createUiDefinition.json) in a new tab of the browser.
- Replace the content of work area in **Create UI Definition Sandbox** with the content of **UI source code `createUiDefinition.json`**.
- Click **Preview** at the left-bottom of **Create UI Definition Sandbox**.
- The UI changes in the existing `Database` tab include:
   - Add two new database types `Microsoft SQL Server` and `PostgreSQL`.
   - The data source connection string example for `Microsoft SQL Server` and `PostgreSQL` are updated accordingly. 

Here are the screenshots of UI changes overview:
* ![image](https://user-images.githubusercontent.com/10357495/202878107-90d4e165-a9af-413a-82e3-a3a5c84e5b8a.png)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>