### PR TITLE
Separate into multiple lines to work around line break issue

### DIFF
--- a/src/main/arm/createUiDefinition.json
+++ b/src/main/arm/createUiDefinition.json
@@ -29,7 +29,7 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "[if(bool(basics('useTrial')), 'By accepting the IBM License Agreement you are accepting the Evaluation terms of the license. An evaluation deployment does not include WebSphere interim fixes (iFixes). The evaluation period runs for 60 days after which you must purchase entitlement to continue to use WebSphere.', 'This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href=\"https://ibm.biz/IBMidEntitlement\" target=\"_blank\">IBM eCustomer Care</a> for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure.')]"
+                    "text": "[if(bool(basics('useTrial')), 'By accepting the IBM License Agreement you are accepting the Evaluation terms of the license. An evaluation<br>deployment does not include WebSphere interim fixes (iFixes). The evaluation period runs for 60 days after which you<br>must purchase entitlement to continue to use WebSphere.', 'This offer is Bring-Your-Own-License. To deploy this offer, you must enter your registered IBMid and your IBMid must<br>have active WebSphere entitlements associated with it. If provisioning fails due to lack of entitlements, ask the primary<br>or secondary contacts for your IBM Passport Advantage site to grant you access or follow steps at <a href=\"https://ibm.biz/IBMidEntitlement\" target=\"_blank\">IBM eCustomer Care</a><br>for further assistance. This offer also assumes you are properly licensed to run offers in Microsoft Azure.')]"
                 }
             },
             {
@@ -80,7 +80,7 @@
                 "type": "Microsoft.Common.InfoBox",
                 "options": {
                     "icon": "Info",
-                    "text": "Check the following box if you agree to share your company's or organization's contact information with IBM for the purpose of discussing IBM offerings."
+                    "text": "Check the following box if you agree to share your company's or organization's contact information with IBM for the<br>purpose of discussing IBM offerings."
                 },
                 "visible": "[bool(basics('useTrial'))]"
             },
@@ -276,7 +276,7 @@
                         "type": "Microsoft.Common.InfoBox",
                         "options": {
                             "icon": "Info",
-                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual network's address prefix. When using an existing virtual network, a minimum virtual network size of /28 and a minimum subnet size of /29 are required. Additionally, the subnet must have adequate available addresses for the server setup."
+                            "text": "When creating a new virtual network, the subnet's address prefix is calculated automatically based on the virtual<br>network's address prefix. When using an existing virtual network, a minimum virtual network size of /28 and a minimum<br>subnet size of /29 are required. Additionally, the subnet must have adequate available addresses for the server setup."
                         }
                     },
                     {


### PR DESCRIPTION
Work around `Declarative Info box cuts off the message` issue by manually separating long line into multiple lines.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>