### PR TITLE
Remove azure javaee in workflows

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -77,7 +77,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -86,32 +85,27 @@ jobs:
         run: |
           echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
           echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
-
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-
       - name: Download arm-ttk used in partner center pipeline
         shell: bash
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
           unzip arm-template-toolkit.zip -d arm-ttk
-
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-
       - name: Checkout websphere-cafe
         uses: actions/checkout@v3
         with:
           repository: Azure-Samples/websphere-cafe
           path: websphere-cafe
-
       - uses: azure/login@v1
         id: azure-login
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -91,10 +91,11 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Download arm-ttk used in partner center pipeline
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v3
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -91,11 +91,11 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Download arm-ttk used in partner center pipeline
-        shell: bash
-        run: |
-          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d arm-ttk
+      - name: Checkout arm-ttk
+        uses: actions/checkout@v3
+        with:
+          repository: Azure/arm-ttk
+          path: arm-ttk
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -91,11 +91,10 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
+      - name: Download arm-ttk used in partner center pipeline
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d arm-ttk
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -98,7 +98,7 @@ jobs:
         shell: bash
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
-          unzip arm-template-toolkit.zip -d ../arm-ttk
+          unzip arm-template-toolkit.zip -d arm-ttk
 
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -74,6 +74,19 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
+
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -68,10 +68,7 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -83,30 +80,25 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
-      - name: Checkout arm-ttk
-        uses: actions/checkout@v3
-        with:
-          repository: Azure/arm-ttk
-          path: arm-ttk
-          ref: ${{ env.refArmttk }}
+
+      - name: Download arm-ttk used in partner center pipeline
+        shell: bash
+        run: |
+          wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
+          unzip arm-template-toolkit.zip -d ../arm-ttk
+
       - name: Checkout ${{ env.repoName }}
         uses: actions/checkout@v3
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
+
       - name: Checkout websphere-cafe
         uses: actions/checkout@v3
         with:
           repository: Azure-Samples/websphere-cafe
           path: websphere-cafe
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+
       - uses: azure/login@v1
         id: azure-login
         with:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -31,11 +31,10 @@ jobs:
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -30,26 +30,31 @@ jobs:
         run: |
           curl -Lo external-deps-versions.properties https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/external-deps-versions.properties
           source external-deps-versions.properties
-          echo "azCliVersion=${AZ_CLI_VERSION}" >> $GITHUB_ENV
           echo "bicepVersion=${BICEP_VERSION}" >> $GITHUB_ENV
-          echo "refArmttk=${ARM_TTK_REFERENCE}" >> $GITHUB_ENV
-          echo "refJavaee=${AZURE_JAVAEE_IAAS_REFERENCE}" >> $GITHUB_ENV
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          server-username: MAVEN_USERNAME # env variable for username
+          server-password: MAVEN_TOKEN # env variable for token
+
+      - name: Set Maven env
+        env:
+          MAVEN_USERNAME: github
+          MAVEN_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          echo "MAVEN_USERNAME=${MAVEN_USERNAME}" >> "$GITHUB_ENV"
+          echo "MAVEN_TOKEN=${MAVEN_TOKEN}" >> "$GITHUB_ENV"
       - name: Set up bicep
         run: |
           curl -Lo bicep https://github.com/Azure/bicep/releases/download/${{ env.bicepVersion }}/bicep-linux-x64
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-      - name: Checkout azure-javaee-iaas
-        uses: actions/checkout@v2
-        with:
-          repository: Azure/azure-javaee-iaas
-          path: azure-javaee-iaas
-          ref: ${{ env.refJavaee }}
+
       - name: Download arm-ttk used in partner center pipeline
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
@@ -59,8 +64,7 @@ jobs:
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-      - name: Build azure-javaee-iaas
-        run: mvn -DskipTests clean install --file azure-javaee-iaas/pom.xml
+
       - name: Build and test ${{ env.repoName }}
         run: |
           cd ${{ env.repoName }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,6 +1,6 @@
 #      Copyright (c) Microsoft Corporation.
 #      Copyright (c) IBM Corporation.
-name: Package ARM
+name: Package ARM and Update Offer Artifact
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -8,7 +8,7 @@ on:
         description: 'Update offer artifact'
         required: true
         type: boolean
-        default: false
+        default: true
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.singleserver

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -38,7 +38,6 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username
           server-password: MAVEN_TOKEN # env variable for token
-
       - name: Set Maven env
         env:
           MAVEN_USERNAME: github
@@ -53,7 +52,6 @@ jobs:
           chmod +x ./bicep
           sudo mv ./bicep /usr/local/bin/bicep
           bicep --version
-
       - name: Download arm-ttk used in partner center pipeline
         run: |
           wget -O arm-template-toolkit.zip https://aka.ms/arm-ttk-azureapps
@@ -63,7 +61,6 @@ jobs:
         with:
           path: ${{ env.repoName }}
           ref: ${{ github.event.inputs.ref }}
-
       - name: Build and test ${{ env.repoName }}
         run: |
           cd ${{ env.repoName }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -3,6 +3,12 @@
 name: Package ARM
 on:
   workflow_dispatch:
+    inputs:
+      updateOfferArtifact:
+        description: 'Update offer artifact'
+        required: true
+        type: boolean
+        default: false
   # Allows you to run this workflow using GitHub APIs
   # PERSONAL_ACCESS_TOKEN=<GITHUB_PERSONAL_ACCESS_TOKEN>
   # REPO_NAME=WASdev/azure.websphere-traditional.singleserver
@@ -81,6 +87,7 @@ jobs:
           name: ${{steps.artifact_file.outputs.artifactName}}
           path: ${{steps.artifact_file.outputs.artifactPath}}      
       - name: Update offer artifact
+        if: ${{ inputs.updateOfferArtifact == true || github.event.client_payload.updateOfferArtifact == true }}
         uses: microsoft/microsoft-partner-center-github-action@v3
         with:
           offerId: ${{ env.offerId }}

--- a/README.md
+++ b/README.md
@@ -34,10 +34,18 @@ Please follow these steps:
     - Click Generate token and make sure to copy the token.
 
 2. Configure Maven Settings
-    - Locate or create the settings.xml file in your .m2 directory.
+    - Locate or create the settings.xml file in your .m2 directory(~/.m2/settings.xml).
     - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
        ```xml
-        <settings>
+        <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 
+                               https://maven.apache.org/xsd/settings-1.2.0.xsd">
+         
+       <!-- other settings
+       ...
+       -->
+      
          <servers>
            <server>
              <id>github</id>
@@ -45,6 +53,11 @@ Please follow these steps:
              <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
            </server>
          </servers>
+      
+       <!-- other settings
+       ...
+       -->
+      
         </settings>
        ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,34 @@
 1. Install [`jq`](https://stedolan.github.io/jq/download/).
 1. Install [Bicep](https://github.com/Azure/bicep/releases) version 0.7.4 or later.
 
+## Local Build Setup and Requirements
+This project utilizes [GitHub Packages](https://github.com/features/packages) for hosting and retrieving some dependencies. To ensure you can smoothly run and build the project in your local environment, specific configuration settings are required.
+
+GitHub Packages requires authentication to download or publish packages. Therefore, you need to configure your Maven `settings.xml` file to authenticate using your GitHub credentials. The primary reason for this is that GitHub Packages does not support anonymous access, even for public packages.
+
+Please follow these steps:
+
+1. Create a Personal Access Token (PAT)
+    - Go to [Personal access tokens](https://github.com/settings/tokens).
+    - Click on Generate new token.
+    - Give your token a descriptive name, set the expiration as needed, and select the scopes (read:packages, write:packages).
+    - Click Generate token and make sure to copy the token.
+
+2. Configure Maven Settings
+    - Locate or create the settings.xml file in your .m2 directory.
+    - Add the GitHub Package Registry server configuration with your username and the PAT you just created. It should look something like this:
+       ```xml
+        <settings>
+         <servers>
+           <server>
+             <id>github</id>
+             <username>YOUR_GITHUB_USERNAME</username>
+             <password>YOUR_PERSONAL_ACCESS_TOKEN</password>
+           </server>
+         </servers>
+        </settings>
+       ```
+
 ## Steps of deployment
 
 1. Checkout [azure-javaee-iaas](https://github.com/Azure/azure-javaee-iaas)

--- a/pom.xml
+++ b/pom.xml
@@ -26,10 +26,9 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.19</version>
-        <relativePath></relativePath>
+        <version>1.0.20</version>
     </parent>
-    
+
     <packaging>jar</packaging>
     <name>${project.artifactId}</name>
 
@@ -37,4 +36,20 @@
         <git.repo>WASdev</git.repo>
         <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}/${project.artifactId}/${git.tag}</artifactsLocationBase>
     </properties>
+
+    <repositories>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.microsoft.azure.iaas</groupId>
         <artifactId>azure-javaee-iaas-parent</artifactId>
-        <version>1.0.20</version>
+        <version>1.0.22</version>
     </parent>
 
     <packaging>jar</packaging>


### PR DESCRIPTION
This pull request includes changes to the GitHub workflow files and the project's build configuration. The most important changes involve the removal of certain environment variables, the addition of Maven environment setup, and the removal of the `azure-javaee-iaas` checkout and build steps in the GitHub workflows. Additionally, the project's `pom.xml` has been updated to include GitHub Packages as a repository, and the README has been updated with instructions for local build setup and requirements.

GitHub workflow updates:

* [`.github/workflows/integration-test.yaml`](diffhunk://#diff-b6766eb8febc0c51651250cd0cdfb44c4f0d3256470d88e62bf82fd46aa73ae0L71-R98): Removed `azCliVersion`, `refArmttk`, and `refJavaee` environment variables. Added Maven environment setup and removed the `azure-javaee-iaas` checkout and build steps. 
* [`.github/workflows/package.yaml`](diffhunk://#diff-154ccb2e01a195c7f4431e94b51c9f2e69bcbda5891ebfbc53b99719cd46e4e2R6-R11): Added input for `updateOfferArtifact` in the workflow dispatch event. Removed `azCliVersion`, `refArmttk`, and `refJavaee` environment variables. Added Maven environment setup and removed the `azure-javaee-iaas` checkout and build steps. The `Update offer artifact` step now only runs if `updateOfferArtifact` is true. 

Build configuration updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L29-R29): Updated the parent version and added GitHub Packages as a repository. 
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23-R50): Added a new section for local build setup and requirements, which includes instructions for setting up GitHub Packages.