### PR TITLE
Refactor: Configure Bicep Apiversions with properties file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.singleserver</artifactId>
-    <version>1.0.28</version>
+    <version>1.0.29</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -52,4 +52,28 @@
             <url>https://maven.pkg.github.com/azure-javaee/azure-javaee-iaas</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <urls>
+                                <file>file:///${basedir}/src/main/resources/azure-common.properties</file>
+                            </urls>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -218,7 +218,7 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@${azure.apiVersion
   }
 }
 
-resource networkInterface 'Microsoft.Network/networkInterfaces@{azure.apiVersionForNetworkInterfaces}' = if (const_newVNet) {
+resource networkInterface 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetworkInterfaces}' = if (const_newVNet) {
   name: name_networkInterface
   location: location
   properties: {
@@ -263,7 +263,7 @@ resource networkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@${azure.ap
   }
 }
 
-resource virtualMachine 'Microsoft.Compute/virtualMachines@{azure.apiVersionForVirtualMachines}' = {
+resource virtualMachine 'Microsoft.Compute/virtualMachines@${azure.apiVersionForVirtualMachines}' = {
   name: name_virtualMachine
   location: location
   properties: {
@@ -323,7 +323,7 @@ module dbConnectionStartPid './modules/_pids/_empty.bicep' = if (enableDB) {
   ]
 }
 
-resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@{azure.apiVersionForVirtualMachineExtensions}' = {
+resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@${azure.apiVersionForVirtualMachineExtensions}' = {
   parent: virtualMachine
   name: 'install'
   location: location

--- a/src/main/bicep/mainTemplate.bicep
+++ b/src/main/bicep/mainTemplate.bicep
@@ -149,7 +149,7 @@ module singleServerStartPid './modules/_pids/_empty.bicep' = {
   params: {}
 }
 
-resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-06-01' = if (const_newVNet) {
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@${azure.apiVersionForNetworkSecurityGroups}' = if (const_newVNet) {
   name: name_networkSecurityGroup
   location: location
   properties: {
@@ -176,7 +176,7 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-06-0
   }
 }
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-06-01' = if (const_newVNet) {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@${azure.apiVersionForVirtualNetworks}' = if (const_newVNet) {
   name: vnetForSingleServer.name
   location: location
   properties: {
@@ -197,17 +197,17 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-06-01' = if (con
   }
 }
 
-resource existingVNet 'Microsoft.Network/virtualNetworks@2023-06-01' existing = if (!const_newVNet) {
+resource existingVNet 'Microsoft.Network/virtualNetworks@${azure.apiVersionForVirtualNetworks}' existing = if (!const_newVNet) {
   name: vnetForSingleServer.name
   scope: resourceGroup(vnetRGNameForSingleServer)
 }
 
-resource existingSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-06-01' existing = if (!const_newVNet) {
+resource existingSubnet 'Microsoft.Network/virtualNetworks/subnets@${azure.apiVersionForVirtualNetworks}' existing = if (!const_newVNet) {
   parent: existingVNet
   name: vnetForSingleServer.subnets.subnet1.name
 }
 
-resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2023-06-01' = if (const_newVNet) {
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@${azure.apiVersionForPublicIPAddresses}' = if (const_newVNet) {
   name: name_publicIPAddress
   location: location
   properties: {
@@ -218,7 +218,7 @@ resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2023-06-01' = if (
   }
 }
 
-resource networkInterface 'Microsoft.Network/networkInterfaces@2023-06-01' = if (const_newVNet) {
+resource networkInterface 'Microsoft.Network/networkInterfaces@{azure.apiVersionForNetworkInterfaces}' = if (const_newVNet) {
   name: name_networkInterface
   location: location
   properties: {
@@ -245,7 +245,7 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2023-06-01' = if 
   ]
 }
 
-resource networkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-06-01' = if (!const_newVNet) {
+resource networkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@${azure.apiVersionForNetworkInterfaces}' = if (!const_newVNet) {
   name: name_networkInterfaceNoPubIp
   location: location
   properties: {
@@ -263,7 +263,7 @@ resource networkInterfaceNoPubIp 'Microsoft.Network/networkInterfaces@2023-06-01
   }
 }
 
-resource virtualMachine 'Microsoft.Compute/virtualMachines@2023-07-01' = {
+resource virtualMachine 'Microsoft.Compute/virtualMachines@{azure.apiVersionForVirtualMachines}' = {
   name: name_virtualMachine
   location: location
   properties: {
@@ -323,7 +323,7 @@ module dbConnectionStartPid './modules/_pids/_empty.bicep' = if (enableDB) {
   ]
 }
 
-resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@2023-07-01' = {
+resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@{azure.apiVersionForVirtualMachineExtensions}' = {
   parent: virtualMachine
   name: 'install'
   location: location

--- a/src/main/resources/azure-common.properties
+++ b/src/main/resources/azure-common.properties
@@ -1,0 +1,61 @@
+## Use the following command to get the latest 10 API versions for a given resource type
+## ```bash
+## export NameSpace=<your_name_space>
+## export ResourceType=<your_resource_type>
+## az provider show --namespace ${NameSpace} --query "resourceTypes[?resourceType=='${ResourceType}'].apiVersions[:10]" \
+## | jq -r '.[][] | select(test("preview$"; "i") | not)' | head -n 10
+## ```
+##
+
+# Microsoft.Authorization/roleAssignments
+azure.apiVersionForRoleAssignment=2022-04-01
+# Microsoft.Authorization/roleDefinitions
+azure.apiVersionForRoleDefinitions=2022-04-01
+# Microsoft.ContainerRegistry/registries
+azure.apiVersionForContainerRegistries=2023-07-01
+# Microsoft.ContainerService/managedClusters
+azure.apiVersionForManagedClusters=2023-08-01
+# Microsoft.Compute/availabilitySets
+azure.apiVersionForAvailabilitySets=2023-07-01
+# Microsoft.Compute/virtualMachines
+azure.apiVersionForVirtualMachines=2024-03-01
+# Microsoft.Compute/virtualMachines/extensions
+azure.apiVersionForVirtualMachineExtensions=2024-03-01
+# Microsoft.Compute/virtualMachineScaleSets
+azure.apiVersionForVirtualMachineScaleSets=2024-03-01
+# Microsoft.KeyVault/vaults
+azure.apiVersionForKeyVault=2022-07-01
+# Microsoft.KeyVault/vaults/secrets
+azure.apiVersionForKeyVaultSecrets=2022-07-01
+# Microsoft.ManagedIdentity/userAssignedIdentities
+azure.apiVersionForIdentity=2023-01-31
+# Microsoft.Network/networkInterfaces
+azure.apiVersionForNetworkInterfaces=2023-11-01
+# Microsoft.Network/networkSecurityGroups
+azure.apiVersionForNetworkSecurityGroups=2023-11-01
+# Microsoft.Network/privateEndpoints
+azure.apiVersionForPrivateEndpoint=2023-11-01
+# Microsoft.Network/publicIPAddresses
+azure.apiVersionForPublicIPAddresses=2023-11-01
+# Microsoft.Network/applicationGateways
+azure.apiVersionForApplicationGateways=2023-11-01
+# Microsoft.Network/dnszones
+azure.apiVersionForDNSZone=2023-07-01-preview
+# Microsoft.Network/virtualNetworks
+azure.apiVersionForVirtualNetworks=2023-11-01
+# Microsoft.OperationalInsights/workspaces
+azure.apiVersionForInsightsWorkspaces=2022-10-01
+# Microsoft.Resources/deploymentScripts
+azure.apiVersionForDeploymentScript=2023-08-01
+# Microsoft.Resources/deployments
+azure.apiVersionForDeployment=2022-09-01
+# Microsoft.Resources/tags
+azure.apiVersionForTags=2023-07-01
+# Microsoft.Storage/storageAccounts
+azure.apiVersionForStorage=2023-05-01
+# Microsoft.Storage/storageAccounts/fileServices
+azure.apiVersionForStorageFileService=2023-05-01
+# Microsoft.Storage/storageAccounts/blobServices
+azure.apiVersionForStorageBlobService=2023-05-01
+# Microsoft.RedHatOpenShift/openShiftClusters
+azure.apiVersionForOpenShiftClusters=2023-04-01


### PR DESCRIPTION
## Updates
Refactor: refactor bicep scripts to use version placeholders so all the versions can be managed in the [azure-common.properties](https://github.com/WASdev/azure.websphere-traditional.singleserver/blob/fea0932ade3d9c207eb5e381bcbbc4df6f47bbf2/src/main/resources/azure-common.properties) file.

## Tests

- [Package ARM and Update Offer Artifact #24](https://github.com/azure-javaee/azure.websphere-traditional.singleserver/actions/runs/9062037077)
- [integration-test #28](https://github.com/azure-javaee/azure.websphere-traditional.singleserver/actions/runs/9062035188)

<img width="1346" alt="image" src="https://github.com/WASdev/azure.websphere-traditional.singleserver/assets/4465723/3ce75f83-f62f-41db-8b78-0170681aa373">
