### PR TITLE
Account for behavior of "gh repo set-default --view" when no default had been set.

### DIFF
--- a/.github/resource/azure-credential-setup.sh
+++ b/.github/resource/azure-credential-setup.sh
@@ -15,7 +15,23 @@ AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv| tr -d '\r\n')
 AZURE_CREDENTIALS=$(az ad sp create-for-rbac --name "$AZURE_CREDENTIALS_SP_NAME" --role owner --scopes /subscriptions/"$AZURE_SUBSCRIPTION_ID" --sdk-auth)
 
 ## Set the Azure Credentials as a secret in the repository
-gh secret --repo $(gh repo set-default --view) set "AZURE_CREDENTIALS" -b"${AZURE_CREDENTIALS}"
-gh variable --repo $(gh repo set-default --view) set "AZURE_CREDENTIALS_SP_NAME" -b"${AZURE_CREDENTIALS_SP_NAME}"
+
+# Get the origin URL and extract the organization/repo
+origin_url=$(git remote get-url origin)
+
+if [[ $origin_url =~ ^git@github.com: ]]; then
+    org_and_repo_name=${origin_url#git@github.com:}
+elif [[ $origin_url =~ ^https://github.com/ ]]; then
+    org_and_repo_name=${origin_url#https://github.com/}
+else
+    echo "Error: Unsupported remote URL format."
+    exit 1
+fi
+
+# Remove the .git suffix
+org_and_repo_name=${org_and_repo_name%.git}
+
+gh secret --repo ${org_and_repo_name} set "AZURE_CREDENTIALS" -b"${AZURE_CREDENTIALS}"
+gh variable --repo ${org_and_repo_name} set "AZURE_CREDENTIALS_SP_NAME" -b"${AZURE_CREDENTIALS_SP_NAME}"
 
 echo "Execute $CURRENT_FILE_NAME - End--------------------------------------------"


### PR DESCRIPTION
I observed `gh secret --repo $(gh repo set-default --view) set "AZURE_CREDENTIALS" -b"${AZURE_CREDENTIALS}"` did not have the expected result if there was no default repo set. Instead, I observed the inner command returned.

```
gh repo set-default --view
no default repository has been set; use `gh repo set-default` to select one
```

This change makes it so the output of `git remote -v` is used to discern the argument to the `--repo` option to `gh secret`. I judge this is more reliable.

modified:   .github/resource/azure-credential-setup.sh