### PR TITLE
Mitigate the impact caused by the upcoming retirement of default outbound in Azure VMs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.ibm.websphere.azure</groupId>
     <artifactId>azure.websphere-traditional.singleserver</artifactId>
-    <version>1.0.40</version>
+    <version>1.0.41</version>
 
     <!-- mvn -Pbicep -Passembly clean install -Ptemplate-validation-tests -->
     <parent>

--- a/src/main/bicep/modules/_deployment-scripts/_dsPostDeployment.bicep
+++ b/src/main/bicep/modules/_deployment-scripts/_dsPostDeployment.bicep
@@ -1,0 +1,54 @@
+/*
+     Copyright (c) Microsoft Corporation.
+     Copyright (c) IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+param _artifactsLocation string = deployment().properties.templateLink.uri
+@secure()
+param _artifactsLocationSasToken string = ''
+param location string
+param name string = ''
+param identity object = {}
+param resourceGroupName string
+param guidTag string
+
+param utcValue string = utcNow()
+
+var const_scriptLocation = uri(_artifactsLocation, 'scripts/')
+
+resource deploymentScript 'Microsoft.Resources/deploymentScripts@${azure.apiVersionForDeploymentScript}' = {
+  name: name
+  location: location
+  kind: 'AzureCLI'
+  identity: identity
+  properties: {
+    azCliVersion: '2.41.0'
+    environmentVariables: [
+      {
+        name: 'RESOURCE_GROUP_NAME'
+        value: resourceGroupName
+      }
+      {
+        name: 'GUID_TAG'
+        value: guidTag
+      }
+    ]
+    primaryScriptUri: uri(const_scriptLocation, 'post-deployment.sh${_artifactsLocationSasToken}')
+
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    forceUpdateTag: utcValue
+  }
+}

--- a/src/main/bicep/modules/_uami/_roleAssignment.bicep
+++ b/src/main/bicep/modules/_uami/_roleAssignment.bicep
@@ -1,0 +1,53 @@
+/*
+     Copyright (c) Microsoft Corporation.
+     Copyright (c) IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+/*
+Description: assign roles cross resource group.
+Usage:
+  module roleAssignment '_roleAssignment.bicep' = {
+    name: 'assign-role'
+    scope: subscription()
+    params: {
+      roleDefinitionId: roleDefinitionId
+      principalId: principalId
+    }
+  }
+*/
+
+targetScope = 'subscription'
+
+// https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+param roleDefinitionId string = ''
+param principalId string = ''
+
+var name_roleAssignmentName = guid('${subscription().id}${principalId}Role assignment in subscription scope')
+
+// Get role resource id in subscription
+resource roleResourceDefinition 'Microsoft.Authorization/roleDefinitions@${azure.apiVersionForRoleDefinitions}' existing = {
+  name: roleDefinitionId
+}
+
+// Assign role
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@${azure.apiVersionForRoleAssignment}' = {
+  name: name_roleAssignmentName
+  properties: {
+    description: 'Assign subscription scope role to User Assigned Managed Identity '
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: roleResourceDefinition.id
+  }
+}

--- a/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
+++ b/src/main/bicep/modules/_uami/_uamiAndRoles.bicep
@@ -1,0 +1,41 @@
+/*
+     Copyright (c) Microsoft Corporation.
+     Copyright (c) IBM Corporation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+param location string
+param name_deploymentScriptContributorRoleAssignmentName string = newGuid()
+
+// https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles
+var const_roleDefinitionIdOfContributor = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+var name_deploymentScriptUserDefinedManagedIdentity = 'twascluster-vm-deployment-script-user-defined-managed-itentity-${substring(uniqueString(name_deploymentScriptContributorRoleAssignmentName),0,5)}'
+
+// UAMI for deployment script
+resource uamiForDeploymentScript 'Microsoft.ManagedIdentity/userAssignedIdentities@${azure.apiVersionForIdentity}' = {
+  name: name_deploymentScriptUserDefinedManagedIdentity
+  location: location
+}
+
+// Assign Contributor role in subscription scope, we need the permission to get/update resource cross resource groups.
+module deploymentScriptUAMICotibutorRoleAssignment '_roleAssignment.bicep' = {
+  name: name_deploymentScriptContributorRoleAssignmentName
+  scope: subscription()
+  params: {
+    roleDefinitionId: const_roleDefinitionIdOfContributor
+    principalId: reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', name_deploymentScriptUserDefinedManagedIdentity)).principalId
+  }
+}
+
+output uamiIdForDeploymentScript string = uamiForDeploymentScript.id

--- a/src/main/scripts/post-deployment.sh
+++ b/src/main/scripts/post-deployment.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#      Copyright (c) Microsoft Corporation.
+#      Copyright (c) IBM Corporation. 
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+# 
+#           http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -Eeuo pipefail
+
+# Go through all public IPs assigned to the network interfaces in resource group ${RESOURCE_GROUP_NAME}, and do the following:
+# * If there is tag named ${GUID_TAG} (regardless of value), update the network interface to remove the public IP
+# Finally, delete all these public IPs at once
+PUBLIC_IPS=$(az network public-ip list --resource-group "${RESOURCE_GROUP_NAME}" --query "[?tags && contains(keys(tags), '${GUID_TAG}')].id" -o tsv)
+if [ -n "${PUBLIC_IPS}" ]; then
+    echo "Found public IPs to remove: ${PUBLIC_IPS}"
+    for PUBLIC_IP in ${PUBLIC_IPS}; do
+        IP_CONFIG_ID=$(az network public-ip show --ids "${PUBLIC_IP}" --query "ipConfiguration.id" -o tsv)
+        if [ -n "${IP_CONFIG_ID}" ]; then
+            echo "Found IP configuration: ${IP_CONFIG_ID}"
+            # Extract NIC name and IP config name from the IP configuration ID
+            # Format: /subscriptions/.../resourceGroups/.../providers/Microsoft.Network/networkInterfaces/NIC_NAME/ipConfigurations/IP_CONFIG_NAME
+            NIC_NAME=$(echo "${IP_CONFIG_ID}" | sed 's|.*/networkInterfaces/\([^/]*\)/.*|\1|')
+            IP_CONFIG_NAME=$(echo "${IP_CONFIG_ID}" | sed 's|.*/ipConfigurations/\([^/]*\).*|\1|')
+            
+            echo "Removing public IP from NIC: ${NIC_NAME}, IP config: ${IP_CONFIG_NAME}"
+            az network nic ip-config update -g "${RESOURCE_GROUP_NAME}" --nic-name "${NIC_NAME}" -n "${IP_CONFIG_NAME}" --remove publicIPAddress
+        fi
+    done
+
+    echo "Deleting public IPs: ${PUBLIC_IPS}"
+    az network public-ip delete --ids ${PUBLIC_IPS}
+else
+    echo "No public IPs found with tag ${GUID_TAG}"
+fi
+
+# Delete uami generated before
+az identity delete --ids ${AZ_SCRIPTS_USER_ASSIGNED_IDENTITY}


### PR DESCRIPTION
To mitigate the impact caused by the [upcoming retirement of default outbound in Azure VMs](https://azure.microsoft.com/en-us/updates?id=default-outbound-access-for-vms-in-azure-will-be-retired-transition-to-a-new-method-of-internet-access) scheduled on September 30, 2025, this PR [adds an explicit outbound method](https://learn.microsoft.com/en-us/azure/virtual-network/ip-services/default-outbound-access#add-an-explicit-outbound-method) by:
1. associating a Standard public IP to any of the virtual machine's network interfaces during the offer deployment
1. adding a unique tag if the public IP should be removed after the deployment, e.g.:
    - Bring your own vNet
    - VMs consisting of a cluster that stand behind a public available load balancer or  a management node
 1. removing these public IPs with the unique tag after the deployment, using the deployment script resource

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>